### PR TITLE
Add playlist/Now Playing features and refine Stream Deck+ dial controls

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Build and Release Stream Deck Plugin
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Read plugin metadata
+        id: meta
+        shell: pwsh
+        run: |
+          $manifestPath = "src/sh.cider.streamdeck.sdPlugin/manifest.json"
+          if (-not (Test-Path $manifestPath)) {
+            throw "Manifest not found at $manifestPath"
+          }
+
+          $manifest = Get-Content $manifestPath -Raw | ConvertFrom-Json
+          $pluginVersion = $manifest.Version
+          if ([string]::IsNullOrWhiteSpace($pluginVersion)) {
+            throw "Version is missing in manifest.json"
+          }
+
+          $artifactName = "CiderDeck-$pluginVersion.streamDeckPlugin"
+
+          "plugin_version=$pluginVersion" >> $env:GITHUB_OUTPUT
+          "artifact_name=$artifactName" >> $env:GITHUB_OUTPUT
+
+      - name: Package plugin
+        id: package
+        shell: pwsh
+        run: |
+          $pluginDir = "src/sh.cider.streamdeck.sdPlugin"
+          $stagingDir = "build/package"
+          $zipPath = "build/$env:ARTIFACT_NAME.zip"
+          $artifactPath = "build/$env:ARTIFACT_NAME"
+
+          Remove-Item $stagingDir -Recurse -Force -ErrorAction SilentlyContinue
+          New-Item -ItemType Directory -Force $stagingDir | Out-Null
+          Copy-Item $pluginDir -Destination "$stagingDir/sh.cider.streamdeck.sdPlugin" -Recurse -Force
+
+          Remove-Item $zipPath -Force -ErrorAction SilentlyContinue
+          Remove-Item $artifactPath -Force -ErrorAction SilentlyContinue
+          Compress-Archive -Path "$stagingDir/*" -DestinationPath $zipPath
+          Move-Item $zipPath $artifactPath
+
+          "artifact_path=$artifactPath" >> $env:GITHUB_OUTPUT
+        env:
+          ARTIFACT_NAME: ${{ steps.meta.outputs.artifact_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.meta.outputs.artifact_name }}
+          path: ${{ steps.package.outputs.artifact_path }}
+
+      - name: Publish GitHub Release (tag pushes)
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: pwsh
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $title = "CiderDeck $tag"
+          $artifact = "${{ steps.package.outputs.artifact_path }}"
+
+          gh release create $tag $artifact --title $title --generate-notes

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,13 @@ jobs:
             throw "Version is missing in manifest.json"
           }
 
-          $artifactName = "CiderDeck-$pluginVersion.streamDeckPlugin"
+          $tagName = "${{ github.ref_name }}"
+          if ([string]::IsNullOrWhiteSpace($tagName)) {
+            $tagName = "manual-${{ github.run_number }}"
+          }
+          $tagName = $tagName -replace '[\\/:*?"<>|]', '-'
+
+          $artifactName = "CiderDeck-$pluginVersion-$tagName.streamDeckPlugin"
 
           "plugin_version=$pluginVersion" >> $env:GITHUB_OUTPUT
           "artifact_name=$artifactName" >> $env:GITHUB_OUTPUT

--- a/README.md
+++ b/README.md
@@ -1,14 +1,13 @@
-
 # CiderDeck
 
-CiderDeck is a plugin for the Elgato Stream Deck that allows you to control your music and show what your currently listening to at a click of a button.
+CiderDeck is a plugin for the Elgato Stream Deck that allows you to control your music and show what you're currently listening to at a click of a button.
 
 ## Description
 
 Using CiderDeck you can do the following
 
-- Show currently playing song's album art.
-- Show currently playing song's name.
+- Launch Cider when it is closed.
+- Show now-playing artwork, song, and artist on a tile.
 - Skip/Rewind
 - Play/Pause
 - Shuffle
@@ -16,11 +15,13 @@ Using CiderDeck you can do the following
 - Change Volume
 - Like/Dislike
 - Add to Library
+- Start a configured playlist
 - and much more to come.
 
 ## Features
 - Written in JavaScript
 - Cross-Platform (macOS, Windows)
+- Stream Deck key and dial support
 
 ## Requirements
 - [Cider 3.0.0+](https://cider.sh)
@@ -30,5 +31,9 @@ Using CiderDeck you can do the following
 ## Installation Guide
 
 Go into the [Releases](https://github.com/ciderapp/CiderDeck/releases) and download the latest compiled plugin file, double click to open it in the Stream Deck software for installation.
+
+## Release Guide
+
+This repo includes a GitHub Actions workflow that builds a `.streamDeckPlugin` package and publishes it to GitHub Releases when you push a tag that starts with `v` (for example: `v3.2.1`).
 
 Done!

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ CiderDeck is a plugin for the Elgato Stream Deck that allows you to control your
 
 Using CiderDeck you can do the following
 
-- Launch Cider when it is closed.
 - Show now-playing artwork, song, and artist on a tile.
 - Skip/Rewind
 - Play/Pause
@@ -37,3 +36,4 @@ Go into the [Releases](https://github.com/ciderapp/CiderDeck/releases) and downl
 This repo includes a GitHub Actions workflow that builds a `.streamDeckPlugin` package and publishes it to GitHub Releases when you push a tag that starts with `v` (for example: `v3.2.1`).
 
 Done!
+

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/album-art-grid-inspector.html
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/album-art-grid-inspector.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Album Art Grid Settings</title>
+    <link rel="stylesheet" href="../../libs/css/sdpi.css">
+</head>
+<body>
+    <div class="sdpi-wrapper">
+        <div class="sdpi-heading">Album Art Grid Settings</div>
+        <div class="sdpi-description">Configure which slice of the current album artwork this button should display.</div>
+
+        <form id="album-art-grid-settings">
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Grid Size</div>
+                <select id="gridSize" class="sdpi-item-value select" data-setting="gridSize">
+                    <option value="1">1 x 1</option>
+                    <option value="2">2 x 2</option>
+                    <option value="3">3 x 3</option>
+                    <option value="4">4 x 4</option>
+                    <option value="5">5 x 5</option>
+                    <option value="6">6 x 6</option>
+                </select>
+            </div>
+
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Tile Row</div>
+                <select id="tileRow" class="sdpi-item-value select" data-setting="tileRow"></select>
+            </div>
+
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Tile Column</div>
+                <select id="tileColumn" class="sdpi-item-value select" data-setting="tileColumn"></select>
+            </div>
+
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Fit Mode</div>
+                <select id="fitMode" class="sdpi-item-value select" data-setting="fitMode">
+                    <option value="cover">Cover</option>
+                    <option value="contain">Contain</option>
+                </select>
+            </div>
+
+            <div class="sdpi-item">
+                <button id="save-settings" class="sdpi-item-value">Save Settings</button>
+            </div>
+
+            <div class="sdpi-item">
+                <button id="reset-settings" class="sdpi-item-value">Reset to Defaults</button>
+            </div>
+        </form>
+    </div>
+
+    <script src="../../libs/js/constants.js"></script>
+    <script src="../../libs/js/utils.js"></script>
+    <script src="../../libs/js/events.js"></script>
+    <script src="../../libs/js/api.js"></script>
+    <script src="../../libs/js/property-inspector.js"></script>
+    <script src="../../libs/js/dynamic-styles.js"></script>
+    <script src="../../libs/js/base-inspector.js"></script>
+    <script src="album-art-grid-inspector.js"></script>
+</body>
+</html>

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/album-art-grid-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/album-art-grid-inspector.js
@@ -1,0 +1,125 @@
+/// <reference path="../../libs/js/property-inspector.js" />
+/// <reference path="../../libs/js/utils.js" />
+/// <reference path="../../libs/js/base-inspector.js" />
+
+let tempSettings = {};
+
+function getDefaultSettings() {
+    return {
+        gridSize: 2,
+        tileRow: 1,
+        tileColumn: 1,
+        fitMode: 'cover'
+    };
+}
+
+function clamp(value, min, max) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return min;
+    }
+
+    return Math.min(max, Math.max(min, Math.floor(numeric)));
+}
+
+function rebuildTileOptions(gridSize) {
+    const size = clamp(gridSize, 1, 6);
+    const rowSelect = document.getElementById('tileRow');
+    const columnSelect = document.getElementById('tileColumn');
+    const selectedRow = clamp(tempSettings.tileRow ?? 1, 1, size);
+    const selectedColumn = clamp(tempSettings.tileColumn ?? 1, 1, size);
+
+    rowSelect.innerHTML = '';
+    columnSelect.innerHTML = '';
+
+    for (let index = 1; index <= size; index += 1) {
+        rowSelect.add(new Option(`${index}`, `${index}`));
+        columnSelect.add(new Option(`${index}`, `${index}`));
+    }
+
+    rowSelect.value = `${selectedRow}`;
+    columnSelect.value = `${selectedColumn}`;
+    tempSettings.tileRow = selectedRow;
+    tempSettings.tileColumn = selectedColumn;
+}
+
+function loadSettingsToUI(settings) {
+    const merged = {
+        ...getDefaultSettings(),
+        ...(settings || {})
+    };
+
+    tempSettings = JSON.parse(JSON.stringify(merged));
+    document.getElementById('gridSize').value = `${merged.gridSize}`;
+    rebuildTileOptions(merged.gridSize);
+    document.getElementById('fitMode').value = merged.fitMode || 'cover';
+}
+
+function collectFormValues() {
+    const gridSize = clamp(document.getElementById('gridSize').value, 1, 6);
+    tempSettings.gridSize = gridSize;
+    tempSettings.tileRow = clamp(document.getElementById('tileRow').value, 1, gridSize);
+    tempSettings.tileColumn = clamp(document.getElementById('tileColumn').value, 1, gridSize);
+    tempSettings.fitMode = document.getElementById('fitMode').value === 'contain' ? 'contain' : 'cover';
+}
+
+function handleSettingsUpdate(settings) {
+    tempSettings = JSON.parse(JSON.stringify(settings || getDefaultSettings()));
+    loadSettingsToUI(tempSettings);
+}
+
+function handleGlobalSettingsUpdate(globalSettings) {
+    if (!globalSettings?.albumArtGrid) {
+        return;
+    }
+
+    baseInspector.actionSettings = { ...baseInspector.actionSettings, ...globalSettings.albumArtGrid };
+    tempSettings = JSON.parse(JSON.stringify(baseInspector.actionSettings));
+    loadSettingsToUI(tempSettings);
+}
+
+function initUI() {
+    document.getElementById('gridSize').addEventListener('change', () => {
+        const gridSize = clamp(document.getElementById('gridSize').value, 1, 6);
+        tempSettings.gridSize = gridSize;
+        rebuildTileOptions(gridSize);
+    });
+
+    document.getElementById('save-settings').addEventListener('click', (event) => {
+        event.preventDefault();
+        collectFormValues();
+
+        baseInspector.actionSettings = JSON.parse(JSON.stringify(tempSettings));
+        baseInspector.syncActionToGlobalSettings();
+        baseInspector.saveActionSettings();
+        baseInspector.saveGlobalSettings();
+
+        const button = document.getElementById('save-settings');
+        const originalText = button.innerText;
+        button.innerText = 'Saved!';
+        setTimeout(() => {
+            button.innerText = originalText;
+        }, 2000);
+    });
+
+    document.getElementById('reset-settings').addEventListener('click', (event) => {
+        event.preventDefault();
+        tempSettings = getDefaultSettings();
+        loadSettingsToUI(tempSettings);
+    });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    initUI();
+
+    if (!baseInspector.globalSettings.albumArtGrid) {
+        baseInspector.globalSettings.albumArtGrid = getDefaultSettings();
+    }
+
+    baseInspector.initialize({
+        actionType: 'albumArtGrid',
+        onActionSettingsReceived: handleSettingsUpdate,
+        onGlobalSettingsReceived: handleGlobalSettingsUpdate,
+        addGlobalSettingsTab: true
+    });
+});

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/dial-inspector.html
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/dial-inspector.html
@@ -27,6 +27,36 @@
         .tab-content.active {
             display: block;
         }
+        .range-item .sdpi-item-value {
+            display: block;
+        }
+        .slider-with-readout {
+            width: 100%;
+        }
+        .slider-with-readout input[type="range"] {
+            width: 100%;
+        }
+        .range-meta {
+            display: grid;
+            grid-template-columns: 1fr auto 1fr;
+            align-items: center;
+            column-gap: 8px;
+            margin-top: 4px;
+            width: 100%;
+            color: #b8b8b8;
+            font-size: 8.5pt;
+        }
+        .range-meta .meta-left {
+            text-align: left;
+        }
+        .range-meta .meta-center {
+            text-align: center;
+            color: #d8d8d8;
+            font-variant-numeric: tabular-nums;
+        }
+        .range-meta .meta-right {
+            text-align: right;
+        }
     </style>
 </head>
 <body>
@@ -51,12 +81,17 @@
                     </select>
                 </div>
                 
-                <div class="sdpi-item">
+                <div class="sdpi-item range-item" id="volume-step-item">
                     <div class="sdpi-item-label">Volume Step</div>
                     <div class="sdpi-item-value">
-                        <span class="clickable" value="1">Fine</span>
-                        <input type="range" min="1" max="10" value="1" data-setting="volumeStep" id="volumeStep">
-                        <span class="clickable" value="10">Coarse</span>
+                        <div class="slider-with-readout">
+                            <input type="range" min="1" max="10" value="1" data-setting="volumeStep" id="volumeStep">
+                        </div>
+                        <div class="range-meta">
+                            <span class="clickable meta-left" value="1">Fine</span>
+                            <span class="meta-center" id="volumeStep-readout">1%</span>
+                            <span class="clickable meta-right" value="10">Coarse</span>
+                        </div>
                     </div>
                 </div>
                 
@@ -74,10 +109,11 @@
                 <div class="sdpi-item">
                     <div class="sdpi-item-label">Touch Behavior</div>
                     <select id="tapBehavior" data-setting="tapBehavior" class="sdpi-item-value select">
+                        <option value="none">None</option>
                         <option value="addToLibrary">Add to Library</option>
+                        <option value="favorite">Favorite</option>
+                        <option value="both">Favorite + Library</option>
                         <option value="dislike">Dislike</option>
-                        <option value="showQueue">Show Queue</option>
-                        <option value="playFavorites">Play Favorites</option>
                     </select>
                 </div>
             </div>
@@ -91,37 +127,60 @@
                     </div>
                 </div>
                 
-                <div class="sdpi-item" id="marquee-speed-container">
+                <div class="sdpi-item range-item" id="marquee-speed-container">
                     <div class="sdpi-item-label">Scroll Speed</div>
                     <div class="sdpi-item-value">
-                        <span class="clickable" value="100">Slow</span>
-                        <input type="range" min="100" max="300" value="200" data-setting="marquee.speed" id="marqueeSpeed">
-                        <span class="clickable" value="300">Fast</span>
+                        <div class="slider-with-readout">
+                            <input type="range" min="100" max="300" value="200" data-setting="marquee.speed" id="marqueeSpeed">
+                        </div>
+                        <div class="range-meta">
+                            <span class="clickable meta-left" value="300">Slower</span>
+                            <span class="meta-center" id="marqueeSpeed-readout">200 ms</span>
+                            <span class="clickable meta-right" value="100">Faster</span>
+                        </div>
                     </div>
                 </div>
                 
-                <div class="sdpi-item" id="marquee-length-container">
+                <div class="sdpi-item range-item" id="marquee-length-container">
                     <div class="sdpi-item-label">Display Length</div>
                     <div class="sdpi-item-value">
-                        <span class="clickable" value="10">Short</span>
-                        <input type="range" min="10" max="25" value="15" data-setting="marquee.length" id="marqueeLength">
-                        <span class="clickable" value="25">Long</span>
+                        <div class="slider-with-readout">
+                            <input type="range" min="10" max="25" value="15" data-setting="marquee.length" id="marqueeLength">
+                        </div>
+                        <div class="range-meta">
+                            <span class="clickable meta-left" value="10">Shorter</span>
+                            <span class="meta-center" id="marqueeLength-readout">15 ch</span>
+                            <span class="clickable meta-right" value="25">Longer</span>
+                        </div>
                     </div>
                 </div>
-                  <div class="sdpi-item" id="marquee-delay-container">
+                  <div class="sdpi-item range-item" id="marquee-delay-container">
                     <div class="sdpi-item-label">Pause Duration</div>
                     <div class="sdpi-item-value">
-                        <span class="clickable" value="1000">Short</span>
-                        <input type="range" min="1000" max="5000" value="2000" data-setting="marquee.delay" id="marqueeDelay">
-                        <span class="clickable" value="5000">Long</span>
+                        <div class="slider-with-readout">
+                            <input type="range" min="1000" max="5000" value="2000" data-setting="marquee.delay" id="marqueeDelay">
+                        </div>
+                        <div class="range-meta">
+                            <span class="clickable meta-left" value="1000">Shorter</span>
+                            <span class="meta-center" id="marqueeDelay-readout">2.0 s</span>
+                            <span class="clickable meta-right" value="5000">Longer</span>
+                        </div>
                     </div>
                 </div>
 
                 <div class="sdpi-item">
                     <div class="sdpi-item-label">Custom Format</div>
                     <div class="sdpi-item-value">
-                        <input id="customFormat" type="text" data-setting="customFormat" placeholder="{song} - {album}" class="sdProperty">
+                        <input id="customFormat" type="text" data-setting="customFormat" placeholder="{artist} - {song}" class="sdProperty">
                     </div>
+                </div>
+
+                <div class="sdpi-item">
+                    <div class="sdpi-item-label">Song Time Text</div>
+                    <select id="timeDisplayMode" data-setting="timeDisplayMode" class="sdpi-item-value select">
+                        <option value="remaining">Time Remaining</option>
+                        <option value="elapsed">Time Played</option>
+                    </select>
                 </div>
                 
                 <div class="sdpi-item">

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/dial-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/dial-inspector.js
@@ -23,6 +23,73 @@ document.addEventListener('DOMContentLoaded', function() {
     setupFunctionalTabSwitching();
 });
 
+function getValueByPath(obj, path) {
+    return path.split('.').reduce((current, key) => current?.[key], obj);
+}
+
+function setValueByPath(obj, path, value) {
+    const keys = path.split('.');
+    let target = obj;
+
+    for (let i = 0; i < keys.length - 1; i++) {
+        const key = keys[i];
+        if (!target[key] || typeof target[key] !== 'object' || Array.isArray(target[key])) {
+            target[key] = {};
+        }
+        target = target[key];
+    }
+
+    target[keys[keys.length - 1]] = value;
+}
+
+function calculateSliderPercent(input) {
+    const min = Number(input.min ?? 0);
+    const max = Number(input.max ?? 100);
+    const value = Number(input.value ?? min);
+    const range = max - min;
+
+    if (range <= 0) {
+        return 100;
+    }
+
+    return Math.round(((value - min) / range) * 100);
+}
+
+function formatSliderReadout(input) {
+    const value = Number(input.value);
+
+    switch (input.id) {
+        case 'volumeStep':
+            return `${value}%`;
+        case 'marqueeSpeed':
+            return `${value} ms`;
+        case 'marqueeLength':
+            return `${value} ch`;
+        case 'marqueeDelay':
+            return `${(value / 1000).toFixed(1)} s`;
+        default:
+            return `${calculateSliderPercent(input)}%`;
+    }
+}
+
+function updateSliderReadout(input) {
+    const readout = document.getElementById(`${input.id}-readout`);
+    if (!readout) return;
+    readout.textContent = formatSliderReadout(input);
+}
+
+function refreshSliderReadouts() {
+    document.querySelectorAll('input[type="range"]').forEach(updateSliderReadout);
+}
+
+function initializeSliderReadouts() {
+    document.querySelectorAll('input[type="range"]').forEach(input => {
+        updateSliderReadout(input);
+        input.addEventListener('input', () => updateSliderReadout(input));
+        input.addEventListener('change', () => updateSliderReadout(input));
+    });
+}
+
 /**
  * Handle settings updates from baseInspector
  * This is called when the action settings are received from Stream Deck
@@ -39,6 +106,7 @@ function handleSettingsUpdate(settings) {
     
     // Update UI state
     updateDependentControls();
+    refreshSliderReadouts();
 }
 
 /**
@@ -62,6 +130,7 @@ function handleGlobalSettingsUpdate(globalSettings) {
         
         // Update UI state
         updateDependentControls();
+        refreshSliderReadouts();
     }
 }
 
@@ -79,22 +148,14 @@ function initUI() {
     document.getElementById('rotationAction').addEventListener('change', function() {
         updateRotationControls();
     });
+
+    initializeSliderReadouts();
     
     // Save button: Apply temporary settings to actual settings and save to Stream Deck
     document.getElementById('save-settings').addEventListener('click', (event) => {
         event.preventDefault();
         
-        // First collect the current form values into tempSettings
         collectFormValues();
-        
-        // Apply temp settings to actual settings
-        baseInspector.actionSettings = JSON.parse(JSON.stringify(tempSettings));
-        
-        // Sync with global settings
-        baseInspector.syncActionToGlobalSettings();
-        
-        // Send the settings to Stream Deck
-        baseInspector.sendSettings();
         
         // Show a success message
         const button = document.getElementById('save-settings');
@@ -116,6 +177,7 @@ function initUI() {
         loadSettingsToUI(tempSettings);
         // Update dependent controls
         updateDependentControls();
+        refreshSliderReadouts();
     });
 
     // Handle range inputs with clickable spans
@@ -128,6 +190,7 @@ function initUI() {
                 // Trigger change event
                 const event = new Event('change');
                 input.dispatchEvent(event);
+                updateSliderReadout(input);
             }
         });
     });
@@ -165,6 +228,7 @@ function setupFunctionalTabSwitching() {
             
             // Update dependent controls
             updateDependentControls();
+            refreshSliderReadouts();
         });
     });
 }
@@ -180,14 +244,17 @@ function collectFormValues() {
         if (!settingName) return;
         
         // Update the setting in tempSettings based on element type
+        let value;
         if (element.type === 'checkbox') {
-            tempSettings[settingName] = element.checked;
+            value = element.checked;
         } else if (element.type === 'range' || element.type === 'number') {
             const numValue = parseInt(element.value, 10);
-            tempSettings[settingName] = isNaN(numValue) ? 0 : numValue;
-        } else if (element.value.trim() !== '') {
-            tempSettings[settingName] = element.value.trim();
+            value = isNaN(numValue) ? 0 : numValue;
+        } else {
+            value = element.value.trim();
         }
+
+        setValueByPath(tempSettings, settingName, value);
     });
 }
 
@@ -200,15 +267,19 @@ function loadSettingsToUI(settings) {
     // Get all form elements with data-setting attributes
     document.querySelectorAll('[data-setting]').forEach(element => {
         const settingName = element.dataset.setting;
-        if (!settingName || settings[settingName] === undefined) return;
+        if (!settingName) return;
+        const value = getValueByPath(settings, settingName);
+        if (value === undefined) return;
         
         // Update the UI element based on its type
         if (element.type === 'checkbox') {
-            element.checked = settings[settingName];
+            element.checked = value;
         } else if (element.type === 'range' || element.type === 'number' || element.type === 'text' || element.tagName === 'SELECT') {
-            element.value = settings[settingName];
+            element.value = value;
         }
     });
+
+    refreshSliderReadouts();
 }
 
 /**
@@ -244,6 +315,6 @@ function updateMarqueeControls() {
  */
 function updateRotationControls() {
     const rotationAction = document.getElementById('rotationAction').value;
-    const volumeStepContainer = document.getElementById('volumeStep').parentNode.parentNode;
+    const volumeStepContainer = document.getElementById('volume-step-item');
     volumeStepContainer.style.display = rotationAction === 'volume' ? 'flex' : 'none';
 }

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.html
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.html
@@ -18,7 +18,7 @@
                     type="text"
                     class="sdpi-item-value"
                     data-setting="playlistId"
-                    placeholder="pl.u-xxxx or https://music.apple.com/.../pl.u-xxxx"
+                    placeholder="p.xxxxx, pl.xxxxx, or full https://music.apple.com/... URL"
                 >
             </div>
 

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.html
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8" />
+    <title>Playlist Button Settings</title>
+    <link rel="stylesheet" href="../../libs/css/sdpi.css">
+</head>
+<body>
+    <div class="sdpi-wrapper">
+        <div class="sdpi-heading">Playlist Button Settings</div>
+        <div class="sdpi-description">Configure the playlist this action should start in Cider.</div>
+
+        <form id="playlist-settings">
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Playlist ID or URL</div>
+                <input
+                    id="playlistId"
+                    type="text"
+                    class="sdpi-item-value"
+                    data-setting="playlistId"
+                    placeholder="pl.u-xxxx or https://music.apple.com/.../pl.u-xxxx"
+                >
+            </div>
+
+            <div class="sdpi-item">
+                <div class="sdpi-item-label">Shuffle</div>
+                <div class="sdpi-item-value">
+                    <input id="shouldShuffle" type="checkbox" data-setting="shouldShuffle" class="sdProperty sdCheckbox">
+                    <label for="shouldShuffle"><span></span></label>
+                </div>
+            </div>
+
+            <div class="sdpi-item">
+                <button id="save-settings" class="sdpi-item-value">Save Settings</button>
+            </div>
+
+            <div class="sdpi-item">
+                <button id="reset-settings" class="sdpi-item-value">Reset to Defaults</button>
+            </div>
+        </form>
+    </div>
+
+    <script src="../../libs/js/constants.js"></script>
+    <script src="../../libs/js/utils.js"></script>
+    <script src="../../libs/js/events.js"></script>
+    <script src="../../libs/js/api.js"></script>
+    <script src="../../libs/js/property-inspector.js"></script>
+    <script src="../../libs/js/dynamic-styles.js"></script>
+    <script src="../../libs/js/base-inspector.js"></script>
+    <script src="playlist-inspector.js"></script>
+</body>
+</html>

--- a/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/actions/inspectors/playlist-inspector.js
@@ -1,0 +1,74 @@
+/// <reference path="../../libs/js/property-inspector.js" />
+/// <reference path="../../libs/js/utils.js" />
+/// <reference path="../../libs/js/base-inspector.js" />
+
+let tempSettings = {};
+
+document.addEventListener('DOMContentLoaded', function() {
+    initUI();
+
+    if (!baseInspector.globalSettings.playlist) {
+        baseInspector.globalSettings.playlist = {
+            playlistId: '',
+            shouldShuffle: false
+        };
+    }
+
+    baseInspector.initialize({
+        actionType: 'playlist',
+        onActionSettingsReceived: handleSettingsUpdate,
+        onGlobalSettingsReceived: handleGlobalSettingsUpdate,
+        addGlobalSettingsTab: true
+    });
+});
+
+function handleSettingsUpdate(settings) {
+    tempSettings = JSON.parse(JSON.stringify(settings || {}));
+    loadSettingsToUI(tempSettings);
+}
+
+function handleGlobalSettingsUpdate(globalSettings) {
+    if (globalSettings?.playlist) {
+        baseInspector.actionSettings = { ...baseInspector.actionSettings, ...globalSettings.playlist };
+        tempSettings = JSON.parse(JSON.stringify(baseInspector.actionSettings));
+        loadSettingsToUI(tempSettings);
+    }
+}
+
+function initUI() {
+    document.getElementById('save-settings').addEventListener('click', (event) => {
+        event.preventDefault();
+        collectFormValues();
+
+        baseInspector.actionSettings = JSON.parse(JSON.stringify(tempSettings));
+        baseInspector.syncActionToGlobalSettings();
+        baseInspector.saveActionSettings();
+        baseInspector.saveGlobalSettings();
+
+        const button = document.getElementById('save-settings');
+        const originalText = button.innerText;
+        button.innerText = "Saved!";
+        setTimeout(() => {
+            button.innerText = originalText;
+        }, 2000);
+    });
+
+    document.getElementById('reset-settings').addEventListener('click', (event) => {
+        event.preventDefault();
+        tempSettings = {
+            playlistId: '',
+            shouldShuffle: false
+        };
+        loadSettingsToUI(tempSettings);
+    });
+}
+
+function collectFormValues() {
+    tempSettings.playlistId = document.getElementById('playlistId').value.trim();
+    tempSettings.shouldShuffle = document.getElementById('shouldShuffle').checked;
+}
+
+function loadSettingsToUI(settings) {
+    document.getElementById('playlistId').value = settings.playlistId || '';
+    document.getElementById('shouldShuffle').checked = Boolean(settings.shouldShuffle);
+}

--- a/src/sh.cider.streamdeck.sdPlugin/app.html
+++ b/src/sh.cider.streamdeck.sdPlugin/app.html
@@ -33,6 +33,7 @@
     <script src="libs/js/volume.js"></script>
     <script src="libs/js/playback.js"></script>
     <script src="libs/js/library.js"></script>
+    <script src="libs/js/album-art-grid.js"></script>
     <script src="libs/js/song-display.js"></script>
 
 	<!-- Plugin Source -->

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -168,18 +168,14 @@ Object.keys(actions).forEach(actionKey => {
                 CiderDeckVolume.handleVolumeChange(null, null, 'down');
                 break;
             case 'ciderLogoAction':
-                if (window.isConnected) {
-                    CiderDeckUtils.comRPC("POST", "playpause");
-                    setTimeout(() => {
-                        CiderDeckUtils.comRPC("GET", "now-playing").then(data => {
-                            if (data && data.status === "ok") {
-                                CiderDeckPlayback.setManualData(data.info);
-                            }
-                        });
-                    }, 1000);
-                } else {
-                    launchCiderApp();
-                }
+                CiderDeckUtils.comRPC("POST", "playpause");
+                setTimeout(() => {
+                    CiderDeckUtils.comRPC("GET", "now-playing").then(data => {
+                        if (data && data.status === "ok") {
+                            CiderDeckPlayback.setManualData(data.info);
+                        }
+                    });
+                }, 1000);
                 break;
             default:
                 console.warn(`[DEBUG] [Action] No handler for ${actionKey}`);
@@ -633,12 +629,6 @@ async function initialize() {
 //  Utility Functions
 // ==========================================================================
 
-function launchCiderApp() {
-    // Cider registers a custom URI scheme on both Windows and macOS.
-    // Opening it asks the OS to start the app if it is installed.
-    $SD.openUrl('cider://');
-}
-
 function setOfflineStates() {
     Object.keys(actions).forEach(actionKey => {
         const contexts = window.contexts[actionKey] || [];
@@ -703,3 +693,4 @@ function resetStates() {
         });
     });
 }
+

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -109,7 +109,7 @@ Object.keys(actions).forEach(actionKey => {
         // Immediately refresh playback-related actions when they become visible
         // so page switches do not show stale song metadata/artwork.
         if (actionKey === 'ciderLogoAction' || actionKey === 'ciderPlaybackAction' || actionKey === 'toggleAction') {
-            pollNowPlaying();
+            requestNowPlayingRefresh();
         }
     });
 
@@ -576,6 +576,13 @@ async function pollNowPlaying() {
     }
 }
 
+function requestNowPlayingRefresh() {
+    // Run an immediate refresh plus short retries to handle page-switch timing.
+    pollNowPlaying();
+    setTimeout(pollNowPlaying, 400);
+    setTimeout(pollNowPlaying, 1200);
+}
+
 function clearCachedData() {
     // Clear all cached data using the cache manager
     cacheManager.clearAll();
@@ -611,10 +618,8 @@ function handlePlaybackEvent({ data, type }) {
             break;
         case "playbackStatus.playbackTimeDidChange":
             CiderDeckPlayback.setPlaybackStatus(data.isPlaying);
-            if (window.contexts.ciderPlaybackAction[0]) {
-                window.currentPlaybackTime = data.currentPlaybackTime;
-                CiderDeckPlayback.setPlaybackTime(data.currentPlaybackTime, data.currentPlaybackDuration);
-            }
+            window.currentPlaybackTime = data.currentPlaybackTime;
+            CiderDeckPlayback.setPlaybackTime(data.currentPlaybackTime, data.currentPlaybackDuration);
             break;
         case "playerStatus.volumeDidChange":
             if (window.contexts.ciderPlaybackAction[0]) {

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -571,6 +571,7 @@ async function pollNowPlaying() {
 
         CiderDeckPlayback.setManualData(data.info);
         CiderDeckPlayback.setAdaptiveData(data.info);
+        CiderDeckPlayback.refreshNowPlayingTile?.();
     } catch (error) {
         console.debug("[DEBUG] [Polling] now-playing poll failed:", error?.message || error);
     }

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -551,7 +551,9 @@ function handleDisconnection() {
     setOfflineStates();
 }
 
-async function pollNowPlaying() {
+async function pollNowPlaying(options = {}) {
+    const forceTileRedraw = Boolean(options.forceTileRedraw);
+
     if (!window.isConnected || !window.token) {
         // Validate redraw state when action appears while disconnected.
         setOfflineStates();
@@ -578,7 +580,9 @@ async function pollNowPlaying() {
             CiderDeckVolume.initializeVolumeDisplay(actions.ciderPlaybackAction, window.contexts.ciderPlaybackAction[0]);
         }
 
-        CiderDeckPlayback.refreshNowPlayingTile?.();
+        if (forceTileRedraw) {
+            CiderDeckPlayback.refreshNowPlayingTile?.();
+        }
     } catch (error) {
         // If the API call fails during redraw, force offline visuals.
         setOfflineStates();
@@ -604,7 +608,7 @@ function requestPluginStateRefresh() {
     }
 
     // Run an immediate refresh plus short retries to handle page-switch timing.
-    pollNowPlaying();
+    pollNowPlaying({ forceTileRedraw: true });
     pluginRefreshRetryTimeout1 = setTimeout(() => {
         pollNowPlaying();
         pluginRefreshRetryTimeout1 = null;

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -31,6 +31,7 @@ let currentAppState = AppState.STARTING_UP;
 let pluginRefreshBurstActive = false;
 let pluginRefreshRetryTimeout1 = null;
 let pluginRefreshRetryTimeout2 = null;
+let dialTouchFlashTimeout = null;
 
 // Initialize actions and contexts
 const actions = {
@@ -109,6 +110,10 @@ Object.keys(actions).forEach(actionKey => {
             console.debug(`[DEBUG] [Context] Context added for ${actionKey}: ${context}`);
         }
 
+        if (actionKey === 'ciderPlaybackAction') {
+            $SD.setFeedbackLayout(context, 'layouts/cider-playback.json');
+        }
+
         // Refresh full plugin state whenever any action appears
         // so page switches do not show stale online/offline or stateful button data.
         requestPluginStateRefresh();
@@ -157,7 +162,7 @@ Object.keys(actions).forEach(actionKey => {
                 CiderDeckPlayback.goBack();
                 break;
             case 'likeAction':
-                CiderDeckLibrary.setRating(1);
+                CiderDeckLibrary.setRating(window.cacheManager.get('rating') === 1 ? 0 : 1);
                 break;
             case 'dislikeAction':
                 CiderDeckLibrary.setRating(-1);
@@ -193,22 +198,27 @@ Object.keys(actions).forEach(actionKey => {
     if (actionKey === 'ciderPlaybackAction') {
         action.onDialDown(() => {
             console.debug(`[DEBUG] [Action] ciderPlaybackAction dial pressed`);
-            // Get press behavior from the hierarchical settings
-            const pressBehavior = window.ciderDeckSettings?.dial?.pressBehavior || 'togglePlay';
+            const pressBehavior = window.ciderDeckSettings?.dial?.pressBehavior
+                ?? window.ciderDeckSettings?.pressBehavior
+                ?? window.pressBehavior
+                ?? 'togglePlay';
             
             switch (pressBehavior) {
                 case 'togglePlay':
                     CiderDeckUtils.comRPC("POST", "playpause");
-                    setTimeout(() => {
-                        CiderDeckUtils.comRPC("GET", "now-playing").then(data => {
-                            if (data && data.status === "ok") {
-                                CiderDeckPlayback.setManualData(data.info);
-                            }
-                        });
-                    }, 1000);
+                    refreshPlaybackStatusSoon();
                     break;
                 case 'mute':
                     CiderDeckVolume.handleVolumeChange(null, window.contexts.ciderPlaybackAction[0], 'mute');
+                    break;
+                case 'favorite':
+                    CiderDeckLibrary.setRating(window.cacheManager.get('rating') === 1 ? 0 : 1);
+                    break;
+                case 'shuffle':
+                    CiderDeckUtils.comRPC("POST", "toggle-shuffle");
+                    break;
+                case 'repeat':
+                    CiderDeckUtils.comRPC("POST", "toggle-repeat");
                     break;
                 default:
                     CiderDeckUtils.comRPC("POST", "playpause");
@@ -216,16 +226,37 @@ Object.keys(actions).forEach(actionKey => {
             }
         });
 
-        action.onDialRotate((jsonObj) => {
-            CiderDeckVolume.handleVolumeChange(actions.ciderPlaybackAction, window.contexts.ciderPlaybackAction[0], null, jsonObj.payload);
+        action.onDialRotate(async (jsonObj) => {
+            const rotationAction = window.ciderDeckSettings?.dial?.rotationAction
+                ?? window.ciderDeckSettings?.rotationAction
+                ?? window.rotationAction
+                ?? 'volume';
+
+            switch (rotationAction) {
+                case 'playbackPos':
+                    await CiderDeckPlayback.rotatePlaybackPosition(jsonObj.payload);
+                    break;
+                case 'skipTrack':
+                    await CiderDeckPlayback.rotateTrackSkip(jsonObj.payload);
+                    break;
+                case 'volume':
+                default:
+                    CiderDeckVolume.handleVolumeChange(actions.ciderPlaybackAction, window.contexts.ciderPlaybackAction[0], null, jsonObj.payload);
+                    break;
+            }
         });
         
         action.onTouchTap(() => {
             console.debug(`[DEBUG] [Action] ciderPlaybackAction touch tapped`);
-            // Get tap behavior from the hierarchical settings
-            const tapBehavior = window.ciderDeckSettings?.dial?.tapBehavior || 'addToLibrary';
+            triggerDialTouchFlash(window.contexts.ciderPlaybackAction[0]);
+            const tapBehavior = window.ciderDeckSettings?.dial?.tapBehavior
+                ?? window.ciderDeckSettings?.tapBehavior
+                ?? window.tapBehavior
+                ?? 'addToLibrary';
             
             switch (tapBehavior) {
+                case 'none':
+                    break;
                 case 'addToLibrary':
                     CiderDeckLibrary.addToLibrary();
                     break;
@@ -235,6 +266,9 @@ Object.keys(actions).forEach(actionKey => {
                 case 'both':
                     CiderDeckLibrary.addToLibrary();
                     CiderDeckLibrary.setRating(1);
+                    break;
+                case 'dislike':
+                    CiderDeckLibrary.setRating(-1);
                     break;
                 default:
                     CiderDeckLibrary.addToLibrary();
@@ -269,6 +303,7 @@ const defaultSettings = {
         volumeStep: 1,
         pressBehavior: 'togglePlay',
         tapBehavior: 'addToLibrary',
+        timeDisplayMode: 'remaining',
         marquee: {
             enabled: true,
             speed: 200,
@@ -277,7 +312,7 @@ const defaultSettings = {
         },
         showIcons: true,
         showArtworkOnDial: true,
-        customFormat: '{song} - {album}',
+        customFormat: '{artist} - {song}',
         textPrefix: ''
     },
     songDisplay: {
@@ -328,12 +363,18 @@ function updateSettings(settings) {
                        mergedSettings.marqueeSettings?.length ?? 15,
         
         // Behavior settings
+        rotationAction: mergedSettings.dial?.rotationAction ?? 'volume',
         tapBehavior: mergedSettings.dial?.tapBehavior ?? 
                     mergedSettings.tapSettings?.tapBehavior ?? 'addToLibrary',
         volumeStep: mergedSettings.dial?.volumeStep ?? 
                    mergedSettings.knobSettings?.volumeStep ?? 1,
         pressBehavior: mergedSettings.dial?.pressBehavior ?? 
                       mergedSettings.knobSettings?.pressBehavior ?? 'togglePlay',
+        timeDisplayMode: mergedSettings.dial?.timeDisplayMode ?? 'remaining',
+        showIcons: mergedSettings.dial?.showIcons ?? true,
+        showArtworkOnDial: mergedSettings.dial?.showArtworkOnDial ?? true,
+        dialCustomFormat: mergedSettings.dial?.customFormat ?? '{artist} - {song}',
+        dialTextPrefix: mergedSettings.dial?.textPrefix ?? '',
         
         // Authentication
         token: mergedSettings.global?.authorization?.rpcKey ?? 
@@ -356,6 +397,69 @@ function updateSettings(settings) {
         currentAppState = AppState.STARTING_UP;
         startupProcess();
     }
+}
+
+function refreshPlaybackStatusSoon() {
+    setTimeout(() => {
+        CiderDeckUtils.comRPC("GET", "now-playing").then(data => {
+            if (data && data.status === "ok") {
+                CiderDeckPlayback.setManualData(data.info);
+            }
+        });
+    }, 1000);
+}
+
+function getDialArtworkFallbackIcon(dialSettings = window.ciderDeckSettings?.dial) {
+    if (dialSettings?.showIcons === false) {
+        return "actions/assets/buttons/blank";
+    }
+    return "actions/assets/buttons/media-playlist";
+}
+
+function getDialVolumeFallbackIcon(dialSettings = window.ciderDeckSettings?.dial) {
+    if (dialSettings?.showIcons === false) {
+        return "actions/assets/buttons/blank";
+    }
+    return "actions/assets/buttons/volume-off";
+}
+
+function createDialTouchFlashOverlay(opacity) {
+    return {
+        key: "pressFlash",
+        type: "text",
+        rect: [0, 0, 200, 100],
+        alignment: "center",
+        background: "#ffffff",
+        opacity,
+        font: {
+            size: 1,
+            weight: 400
+        },
+        value: "",
+        zOrder: 600
+    };
+}
+
+function triggerDialTouchFlash(context) {
+    if (!context) {
+        return;
+    }
+
+    if (dialTouchFlashTimeout) {
+        clearTimeout(dialTouchFlashTimeout);
+        dialTouchFlashTimeout = null;
+    }
+
+    $SD.setFeedback(context, {
+        pressFlash: createDialTouchFlashOverlay(0.16)
+    });
+
+    dialTouchFlashTimeout = setTimeout(() => {
+        $SD.setFeedback(context, {
+            pressFlash: createDialTouchFlashOverlay(0)
+        });
+        dialTouchFlashTimeout = null;
+    }, 120);
 }
 
 $SD.onDidReceiveGlobalSettings(({ payload }) => {
@@ -423,22 +527,36 @@ Object.keys(actions).forEach(actionKey => {
                 if (artwork) {
                     CiderDeckUtils.getBase64Image(artwork).then(art64 => {
                         const showArtworkOnDial = payload.settings.showArtworkOnDial ?? true;
+                        const showIcons = payload.settings.showIcons ?? true;
                         if (window.contexts.ciderPlaybackAction[0]) {
-                            if (showArtworkOnDial) {
+                            if (!showIcons) {
+                                $SD.setFeedback(window.contexts.ciderPlaybackAction[0], { "icon1": "actions/assets/buttons/blank" });
+                            } else if (showArtworkOnDial) {
                                 $SD.setFeedback(window.contexts.ciderPlaybackAction[0], { "icon1": art64 });
                             } else {
                                 $SD.setFeedback(window.contexts.ciderPlaybackAction[0], { "icon1": "actions/assets/buttons/media-playlist" });
                             }
                         }
                     });
+                } else if (window.contexts.ciderPlaybackAction[0]) {
+                    $SD.setFeedback(window.contexts.ciderPlaybackAction[0], {
+                        "icon1": getDialArtworkFallbackIcon(payload.settings)
+                    });
                 }
                 
                 // Also update current song title display if needed
                 const currentSong = cacheManager.get('song');
+                const currentArtist = cacheManager.get('artist');
                 const currentAlbum = cacheManager.get('album');
                 
                 if (currentSong) {
-                    const fullTitle = `${currentSong} - ${currentAlbum || ''}`;
+                    const customFormat = payload.settings.customFormat || '{artist} - {song}';
+                    const textPrefix = payload.settings.textPrefix || '';
+                    const fullTitle = textPrefix + CiderDeckPlayback.formatSongInfo(customFormat, {
+                        title: currentSong,
+                        artist: currentArtist,
+                        album: currentAlbum
+                    });
                     CiderDeckMarquee.clearMarquee();
                     
                     const marqueeSettings = payload.settings.marquee || {};
@@ -455,6 +573,11 @@ Object.keys(actions).forEach(actionKey => {
                 
                 // Update volume display if needed
                 if (window.contexts.ciderPlaybackAction[0]) {
+                    const currentPlaybackTime = cacheManager.get('currentPlaybackTime');
+                    const currentPlaybackDuration = cacheManager.get('currentPlaybackDuration');
+                    if (currentPlaybackTime !== null && currentPlaybackDuration !== null) {
+                        CiderDeckPlayback.setPlaybackTime(currentPlaybackTime, currentPlaybackDuration);
+                    }
                     CiderDeckVolume.initializeVolumeDisplay(actions.ciderPlaybackAction, window.contexts.ciderPlaybackAction[0]);
                 }
             }
@@ -730,10 +853,12 @@ function setOfflineStates() {
 
         if (actionKey === 'ciderPlaybackAction') {
             const feedbackPayload = {
-                "icon1": "actions/assets/buttons/media-playlist",
-                "icon2": "actions/assets/buttons/volume-off",
+                "icon1": getDialArtworkFallbackIcon(),
+                "icon2": getDialVolumeFallbackIcon(),
                 "indicator1": 0,
                 "indicator2": 0,
+                "progressText": "--:--",
+                "volumeText": "0%",
                 "title": "Cider - Offline",
             };
             contexts.forEach(context => {
@@ -759,8 +884,10 @@ function resetStates() {
 
             if (actionKey === 'ciderPlaybackAction') {
                 const feedbackPayload = {
-                    "icon1": "actions/assets/buttons/media-playlist",
-                    "icon2": "actions/assets/buttons/volume-off",
+                    "icon1": getDialArtworkFallbackIcon(),
+                    "icon2": getDialVolumeFallbackIcon(),
+                    "progressText": "--:--",
+                    "volumeText": "0%",
                     "title": "Cider - N/A",
                 };
                 $SD.setFeedback(context, feedbackPayload);

--- a/src/sh.cider.streamdeck.sdPlugin/app.js
+++ b/src/sh.cider.streamdeck.sdPlugin/app.js
@@ -14,6 +14,7 @@
 /// <reference path="libs/js/playback.js" />
 /// <reference path="libs/js/library.js" />
 /// <reference path="libs/js/volume.js" />
+/// <reference path="libs/js/album-art-grid.js" />
 /// <reference path="libs/js/song-display.js" />
 
 // ==========================================================================
@@ -44,6 +45,7 @@ const actions = {
     dislikeAction: new Action('sh.cider.streamdeck.dislike'),
     addToLibraryAction: new Action('sh.cider.streamdeck.addtolibrary'),
     playlistAction: new Action('sh.cider.streamdeck.playlist'),
+    albumArtGridAction: new Action('sh.cider.streamdeck.albumartgrid'),
     volumeUpAction: new Action('sh.cider.streamdeck.volumeup'),
     volumeDownAction: new Action('sh.cider.streamdeck.volumedown'),
     ciderLogoAction: new Action('sh.cider.streamdeck.ciderlogo'),
@@ -63,6 +65,7 @@ const offlineStates = {
     'sh.cider.streamdeck.volumedown': 1,
     'sh.cider.streamdeck.addtolibrary': 2,
     'sh.cider.streamdeck.playlist': 1,
+    'sh.cider.streamdeck.albumartgrid': 1,
     'sh.cider.streamdeck.dislike': 2,
     'sh.cider.streamdeck.like': 2,
     'sh.cider.streamdeck.skip': 1,
@@ -75,6 +78,27 @@ window.isConnected = false;
 
 // Ensure window.contexts is initialized
 window.contexts = window.contexts || {};
+window.actionContextSettings = window.actionContextSettings || {};
+
+function storeContextSettings(actionKey, context, details = {}) {
+    if (!actionKey || !context) {
+        return;
+    }
+
+    window.actionContextSettings[actionKey] = window.actionContextSettings[actionKey] || {};
+    window.actionContextSettings[actionKey][context] = {
+        ...(window.actionContextSettings[actionKey][context] || {}),
+        ...details
+    };
+}
+
+function removeContextSettings(actionKey, context) {
+    if (!actionKey || !context || !window.actionContextSettings[actionKey]) {
+        return;
+    }
+
+    delete window.actionContextSettings[actionKey][context];
+}
 
 // ==========================================================================
 //  Initialization and Setup
@@ -94,6 +118,14 @@ $SD.onConnected(() => {
     $SD.getGlobalSettings();
 });
 
+$SD.onDeviceDidConnect(({ device, deviceInfo }) => {
+    window.CiderDeckAlbumArtGrid?.registerDevice(device, deviceInfo);
+});
+
+$SD.onDeviceDidDisconnect(({ device }) => {
+    window.CiderDeckAlbumArtGrid?.unregisterDevice(device);
+});
+
 // ==========================================================================
 //  Context Management
 // ==========================================================================
@@ -110,8 +142,21 @@ Object.keys(actions).forEach(actionKey => {
             console.debug(`[DEBUG] [Context] Context added for ${actionKey}: ${context}`);
         }
 
+        storeContextSettings(actionKey, context, {
+            settings: payload?.settings || {},
+            device: payload?.device || null
+        });
+
         if (actionKey === 'ciderPlaybackAction') {
             $SD.setFeedbackLayout(context, 'layouts/cider-playback.json');
+        }
+
+        if (actionKey === 'albumArtGridAction') {
+            window.CiderDeckAlbumArtGrid?.registerContext(context, {
+                device: payload?.device || null,
+                settings: payload?.settings || {}
+            });
+            window.CiderDeckAlbumArtGrid?.refreshContext(context);
         }
 
         // Refresh full plugin state whenever any action appears
@@ -124,6 +169,11 @@ Object.keys(actions).forEach(actionKey => {
         if (index > -1) {
             window.contexts[actionKey].splice(index, 1);
             console.debug(`[DEBUG] [Context] Context removed for ${actionKey}: ${context}`);
+        }
+        removeContextSettings(actionKey, context);
+
+        if (actionKey === 'albumArtGridAction') {
+            window.CiderDeckAlbumArtGrid?.unregisterContext(context);
         }
 
         if (actionKey === 'ciderPlaybackAction' || actionKey === 'ciderLogoAction') {
@@ -172,6 +222,9 @@ Object.keys(actions).forEach(actionKey => {
                 break;
             case 'playlistAction':
                 CiderDeckLibrary.playPlaylist(jsonObj?.payload?.settings || {});
+                break;
+            case 'albumArtGridAction':
+                window.CiderDeckAlbumArtGrid?.refreshContext(jsonObj?.context);
                 break;
             case 'volumeUpAction':
                 CiderDeckVolume.handleVolumeChange(null, null, 'up');
@@ -297,6 +350,12 @@ const defaultSettings = {
     playlist: {
         playlistId: '',
         shouldShuffle: false
+    },
+    albumArtGrid: {
+        gridSize: 2,
+        tileRow: 1,
+        tileColumn: 1,
+        fitMode: 'cover'
     },
     dial: {
         rotationAction: 'volume',
@@ -474,6 +533,20 @@ $SD.onDidReceiveGlobalSettings(({ payload }) => {
 // Add listeners for each action to handle direct PI notifications
 Object.keys(actions).forEach(actionKey => {
     const action = actions[actionKey];
+
+    action.onDidReceiveSettings(({ context, payload }) => {
+        if (!context) {
+            return;
+        }
+
+        storeContextSettings(actionKey, context, {
+            settings: payload?.settings || {}
+        });
+
+        if (actionKey === 'albumArtGridAction') {
+            window.CiderDeckAlbumArtGrid?.updateContextSettings(context, payload?.settings || {});
+        }
+    });
     
     // Listen for direct messages from Property Inspector
     action.onSendToPlugin((data) => {
@@ -580,6 +653,13 @@ Object.keys(actions).forEach(actionKey => {
                     }
                     CiderDeckVolume.initializeVolumeDisplay(actions.ciderPlaybackAction, window.contexts.ciderPlaybackAction[0]);
                 }
+            }
+
+            if (payload.actionType === 'albumArtGrid' && data.context) {
+                storeContextSettings(actionKey, data.context, {
+                    settings: payload.settings || {}
+                });
+                window.CiderDeckAlbumArtGrid?.updateContextSettings(data.context, payload.settings || {});
             }
         }
         
@@ -831,6 +911,7 @@ async function initialize() {
 // ==========================================================================
 
 function setOfflineStates() {
+    window.CiderDeckAlbumArtGrid?.setOfflineStates();
     Object.keys(actions).forEach(actionKey => {
         const contexts = window.contexts[actionKey] || [];
         const uuid = actions[actionKey].UUID;
@@ -869,6 +950,7 @@ function setOfflineStates() {
 }
 
 function resetStates() {
+    window.CiderDeckAlbumArtGrid?.setDefaultStates();
     Object.keys(actions).forEach(actionKey => {
         const contexts = window.contexts[actionKey] || [];
         contexts.forEach(context => {

--- a/src/sh.cider.streamdeck.sdPlugin/en.json
+++ b/src/sh.cider.streamdeck.sdPlugin/en.json
@@ -7,8 +7,8 @@
     "Tooltip": "Provides various controls for managing your media through Cider."
   },
   "sh.cider.streamdeck.ciderlogo": {
-    "Name": "Launch / Now Playing",
-    "Tooltip": "Shows Cider when offline and now-playing artwork with song info when online."
+    "Name": "Now Playing",
+    "Tooltip": "Shows now-playing artwork with song info and toggles playback in Cider."
   },
   "sh.cider.streamdeck.toggle": {
     "Name": "Toggle Playback", 
@@ -33,3 +33,4 @@
     "Button": "Button"
   }
 }
+

--- a/src/sh.cider.streamdeck.sdPlugin/en.json
+++ b/src/sh.cider.streamdeck.sdPlugin/en.json
@@ -6,17 +6,17 @@
     "Name": "Cider Playback", 
     "Tooltip": "Provides various controls for managing your media through Cider."
   },
-  "sh.cider.streamdeck.songname": {
-    "Name": "Song Name", 
-    "Tooltip": "Provides a tile to show the currently playing song from Cider."
-  },
-  "sh.cider.streamdeck.albumart": {
-    "Name": "Album Art", 
-    "Tooltip": "Provides a tile to show the currently playing song's Album Art from Cider."
+  "sh.cider.streamdeck.ciderlogo": {
+    "Name": "Launch / Now Playing",
+    "Tooltip": "Shows Cider when offline and now-playing artwork with song info when online."
   },
   "sh.cider.streamdeck.toggle": {
     "Name": "Toggle Playback", 
     "Tooltip": "Provides a tile to toggle the currently playing song in Cider."
+  },
+  "sh.cider.streamdeck.playlist": {
+    "Name": "Play Playlist",
+    "Tooltip": "Starts a configured Apple Music playlist in Cider."
   },
   "sh.cider.streamdeck.skip": {
     "Name": "Skip", 

--- a/src/sh.cider.streamdeck.sdPlugin/en.json
+++ b/src/sh.cider.streamdeck.sdPlugin/en.json
@@ -18,6 +18,10 @@
     "Name": "Play Playlist",
     "Tooltip": "Starts a configured Apple Music playlist in Cider."
   },
+  "sh.cider.streamdeck.albumartgrid": {
+    "Name": "Album Art Tile",
+    "Tooltip": "Displays one tile of the current album artwork so you can build larger album-art grids."
+  },
   "sh.cider.streamdeck.skip": {
     "Name": "Skip", 
     "Tooltip": "Provides a tile to skip the currently playing song in Cider."

--- a/src/sh.cider.streamdeck.sdPlugin/layouts/cider-playback.json
+++ b/src/sh.cider.streamdeck.sdPlugin/layouts/cider-playback.json
@@ -1,0 +1,98 @@
+{
+    "$schema": "https://schemas.elgato.com/streamdeck/plugins/layout.json",
+    "id": "cider-playback",
+    "items": [
+        {
+            "key": "title",
+            "type": "text",
+            "rect": [12, 8, 176, 18],
+            "alignment": "left",
+            "font": {
+                "size": 14,
+                "weight": 500
+            },
+            "text-overflow": "fade",
+            "value": "Cider - N/A"
+        },
+        {
+            "key": "icon1",
+            "type": "pixmap",
+            "rect": [12, 34, 20, 20],
+            "value": "actions/assets/buttons/media-playlist"
+        },
+        {
+            "key": "indicator1",
+            "type": "bar",
+            "rect": [40, 39, 118, 10],
+            "subtype": 4,
+            "border_w": 0,
+            "bar_bg_c": "#585858",
+            "bar_fill_c": "#e41b56",
+            "range": {
+                "min": 0,
+                "max": 100
+            },
+            "value": 0
+        },
+        {
+            "key": "progressText",
+            "type": "text",
+            "rect": [162, 33, 26, 18],
+            "alignment": "right",
+            "color": "#ffffff",
+            "font": {
+                "size": 10,
+                "weight": 400
+            },
+            "text-overflow": "clip",
+            "value": "-0:00"
+        },
+        {
+            "key": "icon2",
+            "type": "pixmap",
+            "rect": [12, 62, 20, 20],
+            "value": "actions/assets/buttons/volume-off"
+        },
+        {
+            "key": "indicator2",
+            "type": "bar",
+            "rect": [40, 67, 118, 10],
+            "subtype": 4,
+            "border_w": 0,
+            "bar_bg_c": "#585858",
+            "bar_fill_c": "#ffffff",
+            "range": {
+                "min": 0,
+                "max": 100
+            },
+            "value": 0
+        },
+        {
+            "key": "volumeText",
+            "type": "text",
+            "rect": [162, 61, 26, 18],
+            "alignment": "right",
+            "color": "#ffffff",
+            "font": {
+                "size": 10,
+                "weight": 400
+            },
+            "text-overflow": "clip",
+            "value": "0%"
+        },
+        {
+            "key": "pressFlash",
+            "type": "text",
+            "rect": [0, 0, 200, 100],
+            "alignment": "center",
+            "background": "#ffffff",
+            "opacity": 0,
+            "font": {
+                "size": 1,
+                "weight": 400
+            },
+            "value": "",
+            "zOrder": 600
+        }
+    ]
+}

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/album-art-grid.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/album-art-grid.js
@@ -1,0 +1,301 @@
+/**
+ * CiderDeck Album Art Grid
+ *
+ * Renders the current artwork across multiple keypad buttons by cropping
+ * a square source image into per-tile images.
+ */
+
+const albumArtGridLogger = window.CiderDeckLogger?.createLogger('AlbumArtGrid') || {
+    info: console.log,
+    debug: console.debug,
+    warn: console.warn,
+    error: console.error,
+    category: () => ({
+        info: console.log,
+        debug: console.debug,
+        warn: console.warn,
+        error: console.error
+    })
+};
+
+const DEFAULT_TILE_RENDER_SIZE = 144;
+const DEVICE_TILE_RENDER_SIZE = {
+    default: 144
+};
+
+const albumArtGridContexts = new Map();
+const albumArtGridDevices = new Map();
+const albumArtGridImageCache = new Map();
+const albumArtGridTileCache = new Map();
+
+function clampNumber(value, min, max) {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric)) {
+        return min;
+    }
+
+    return Math.min(max, Math.max(min, Math.floor(numeric)));
+}
+
+function normalizeGridSettings(settings = {}) {
+    const gridSize = clampNumber(settings.gridSize ?? 2, 1, 6);
+    const tileRow = clampNumber(settings.tileRow ?? 1, 1, gridSize);
+    const tileColumn = clampNumber(settings.tileColumn ?? 1, 1, gridSize);
+    const fitMode = settings.fitMode === 'contain' ? 'contain' : 'cover';
+
+    return {
+        gridSize,
+        tileRow,
+        tileColumn,
+        fitMode
+    };
+}
+
+function getDeviceTileRenderSize(device) {
+    const deviceInfo = device ? albumArtGridDevices.get(device) : null;
+    const deviceType = deviceInfo?.type;
+
+    if (deviceType !== undefined && Object.prototype.hasOwnProperty.call(DEVICE_TILE_RENDER_SIZE, deviceType)) {
+        return DEVICE_TILE_RENDER_SIZE[deviceType];
+    }
+
+    return DEVICE_TILE_RENDER_SIZE.default || DEFAULT_TILE_RENDER_SIZE;
+}
+
+function getDefaultTileImage() {
+    return "actions/assets/buttons/icon";
+}
+
+function setDefaultTile(context) {
+    if (!context) {
+        return;
+    }
+
+    $SD.setState(context, 0);
+    $SD.setImage(context, getDefaultTileImage(), 0);
+}
+
+function setOfflineTile(context) {
+    if (!context) {
+        return;
+    }
+
+    $SD.setState(context, 1);
+}
+
+function loadArtworkImage(artworkUrl) {
+    if (!artworkUrl) {
+        return Promise.resolve(null);
+    }
+
+    if (albumArtGridImageCache.has(artworkUrl)) {
+        return albumArtGridImageCache.get(artworkUrl);
+    }
+
+    const imagePromise = new Promise((resolve, reject) => {
+        const image = new Image();
+        image.crossOrigin = 'anonymous';
+        image.onload = () => resolve(image);
+        image.onerror = () => reject(new Error(`Failed to load artwork: ${artworkUrl}`));
+        image.src = artworkUrl;
+    });
+
+    albumArtGridImageCache.set(artworkUrl, imagePromise);
+    return imagePromise;
+}
+
+function drawArtworkTile(sourceImage, settings, tileSize) {
+    const { gridSize, tileRow, tileColumn, fitMode } = settings;
+    const sourceWidth = sourceImage.naturalWidth || sourceImage.width;
+    const sourceHeight = sourceImage.naturalHeight || sourceImage.height;
+    const masterSize = gridSize * tileSize;
+
+    const masterCanvas = document.createElement('canvas');
+    masterCanvas.width = masterSize;
+    masterCanvas.height = masterSize;
+    const masterContext = masterCanvas.getContext('2d');
+
+    masterContext.clearRect(0, 0, masterSize, masterSize);
+    masterContext.fillStyle = '#000000';
+    masterContext.fillRect(0, 0, masterSize, masterSize);
+
+    const scale = fitMode === 'contain'
+        ? Math.min(masterSize / sourceWidth, masterSize / sourceHeight)
+        : Math.max(masterSize / sourceWidth, masterSize / sourceHeight);
+
+    const drawWidth = sourceWidth * scale;
+    const drawHeight = sourceHeight * scale;
+    const drawX = (masterSize - drawWidth) / 2;
+    const drawY = (masterSize - drawHeight) / 2;
+
+    masterContext.drawImage(sourceImage, drawX, drawY, drawWidth, drawHeight);
+
+    const tileCanvas = document.createElement('canvas');
+    tileCanvas.width = tileSize;
+    tileCanvas.height = tileSize;
+    const tileContext = tileCanvas.getContext('2d');
+
+    const sourceX = (tileColumn - 1) * tileSize;
+    const sourceY = (tileRow - 1) * tileSize;
+    tileContext.drawImage(masterCanvas, sourceX, sourceY, tileSize, tileSize, 0, 0, tileSize, tileSize);
+
+    return tileCanvas.toDataURL('image/png');
+}
+
+async function renderArtworkTile(artworkUrl, settings, tileSize) {
+    const cacheKey = JSON.stringify({
+        artworkUrl,
+        tileSize,
+        gridSize: settings.gridSize,
+        tileRow: settings.tileRow,
+        tileColumn: settings.tileColumn,
+        fitMode: settings.fitMode
+    });
+
+    if (albumArtGridTileCache.has(cacheKey)) {
+        return albumArtGridTileCache.get(cacheKey);
+    }
+
+    const sourceImage = await loadArtworkImage(artworkUrl);
+    if (!sourceImage) {
+        return null;
+    }
+
+    const tileDataUrl = drawArtworkTile(sourceImage, settings, tileSize);
+    albumArtGridTileCache.set(cacheKey, tileDataUrl);
+    return tileDataUrl;
+}
+
+function clearTileCacheForArtwork(artworkUrl) {
+    if (!artworkUrl) {
+        return;
+    }
+
+    Array.from(albumArtGridTileCache.keys()).forEach((cacheKey) => {
+        if (cacheKey.includes(artworkUrl)) {
+            albumArtGridTileCache.delete(cacheKey);
+        }
+    });
+}
+
+async function refreshContext(context) {
+    const contextInfo = albumArtGridContexts.get(context);
+    if (!contextInfo) {
+        return;
+    }
+
+    if (!window.isConnected) {
+        setOfflineTile(context);
+        return;
+    }
+
+    const artworkUrl = window.cacheManager?.get('artwork');
+    if (!artworkUrl) {
+        setDefaultTile(context);
+        return;
+    }
+
+    try {
+        const tileSize = getDeviceTileRenderSize(contextInfo.device);
+        const tileDataUrl = await renderArtworkTile(artworkUrl, contextInfo.settings, tileSize);
+        if (!tileDataUrl) {
+            setDefaultTile(context);
+            return;
+        }
+
+        $SD.setState(context, 0);
+        $SD.setImage(context, tileDataUrl, 0);
+    } catch (error) {
+        albumArtGridLogger.error(`Failed to render album art tile for ${context}: ${error}`);
+        setDefaultTile(context);
+    }
+}
+
+function registerContext(context, details = {}) {
+    if (!context) {
+        return;
+    }
+
+    const existing = albumArtGridContexts.get(context) || {};
+    albumArtGridContexts.set(context, {
+        ...existing,
+        device: details.device ?? existing.device ?? null,
+        settings: normalizeGridSettings(details.settings ?? existing.settings ?? {})
+    });
+}
+
+function updateContextSettings(context, settings = {}) {
+    if (!context) {
+        return;
+    }
+
+    registerContext(context, { settings });
+    refreshContext(context);
+}
+
+function unregisterContext(context) {
+    albumArtGridContexts.delete(context);
+}
+
+function registerDevice(device, deviceInfo = {}) {
+    if (!device) {
+        return;
+    }
+
+    albumArtGridDevices.set(device, deviceInfo);
+}
+
+function unregisterDevice(device) {
+    if (!device) {
+        return;
+    }
+
+    albumArtGridDevices.delete(device);
+}
+
+function refreshAll() {
+    albumArtGridContexts.forEach((_, context) => {
+        refreshContext(context);
+    });
+}
+
+function notifyArtworkChanged(previousArtworkUrl, nextArtworkUrl) {
+    if (previousArtworkUrl && previousArtworkUrl !== nextArtworkUrl) {
+        clearTileCacheForArtwork(previousArtworkUrl);
+    }
+
+    if (nextArtworkUrl) {
+        refreshAll();
+        return;
+    }
+
+    albumArtGridContexts.forEach((_, context) => {
+        setDefaultTile(context);
+    });
+}
+
+function setDefaultStates() {
+    albumArtGridContexts.forEach((_, context) => {
+        setDefaultTile(context);
+    });
+}
+
+function setOfflineStates() {
+    albumArtGridContexts.forEach((_, context) => {
+        setOfflineTile(context);
+    });
+}
+
+window.CiderDeckAlbumArtGrid = {
+    normalizeGridSettings,
+    registerContext,
+    updateContextSettings,
+    unregisterContext,
+    registerDevice,
+    unregisterDevice,
+    refreshContext,
+    refreshAll,
+    notifyArtworkChanged,
+    setDefaultStates,
+    setOfflineStates
+};

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
@@ -56,6 +56,10 @@ class BaseInspector {
                     speed: 40,
                     pause: 2000
                 }
+            },
+            playlist: {
+                playlistId: '',
+                shouldShuffle: false
             }
         };
 

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
@@ -63,6 +63,12 @@ class BaseInspector {
             playlist: {
                 playlistId: '',
                 shouldShuffle: false
+            },
+            albumArtGrid: {
+                gridSize: 2,
+                tileRow: 1,
+                tileColumn: 1,
+                fitMode: 'cover'
             }
         };
 

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/base-inspector.js
@@ -23,6 +23,7 @@ class BaseInspector {
                 volumeStep: 1,
                 pressBehavior: 'togglePlay',
                 tapBehavior: 'addToLibrary',
+                timeDisplayMode: 'remaining',
                 marquee: {
                     enabled: true,
                     speed: 200,
@@ -30,7 +31,9 @@ class BaseInspector {
                     delay: 2000
                 },
                 showIcons: true,
-                showArtworkOnDial: true
+                showArtworkOnDial: true,
+                customFormat: '{artist} - {song}',
+                textPrefix: ''
             },
             songDisplay: {
                 fontSize: 16,
@@ -69,9 +72,12 @@ class BaseInspector {
         this.saveGlobalSettings = this.saveGlobalSettings.bind(this);
         this.loadActionSettings = this.loadActionSettings.bind(this);
         this.saveActionSettings = this.saveActionSettings.bind(this);
+        this.sendSettings = this.sendSettings.bind(this);
         this.addGlobalSettingsTab = this.addGlobalSettingsTab.bind(this);
         this.setupGlobalSettingsEvents = this.setupGlobalSettingsEvents.bind(this);
         this.setupTabSwitching = this.setupTabSwitching.bind(this);
+        this.getValueByPath = this.getValueByPath.bind(this);
+        this.setValueByPath = this.setValueByPath.bind(this);
     }
 
     /**
@@ -273,10 +279,9 @@ class BaseInspector {
                     value = settings.authorization?.rpcKey;
                 }
             } else {
-                // For action settings, just get the value directly
                 const settingName = element.dataset.setting;
                 if (!settingName) return;
-                value = settings[settingName];
+                value = this.getValueByPath(settings, settingName);
             }
             
             // Set the form field value based on its type
@@ -408,22 +413,25 @@ class BaseInspector {
      * Save action-specific settings back to Stream Deck
      */
     saveActionSettings() {
-        const newSettings = {};
+        const newSettings = JSON.parse(JSON.stringify(this.actionSettings || {}));
         
         document.querySelectorAll('[data-setting]').forEach(element => {
             const settingName = element.dataset.setting;
             if (!settingName) return;
             
+            let value;
             if (element.type === 'checkbox') {
-                newSettings[settingName] = element.checked;
+                value = element.checked;
             } else if (element.type === 'range' || element.type === 'number') {
                 const numValue = parseInt(element.value, 10);
-                newSettings[settingName] = isNaN(numValue) ? 0 : numValue;
+                value = isNaN(numValue) ? 0 : numValue;
             } else if (element.type === 'color') {
-                newSettings[settingName] = element.value;
-            } else if (element.value.trim() !== '') {
-                newSettings[settingName] = element.value.trim();
+                value = element.value;
+            } else {
+                value = element.value.trim();
             }
+
+            this.setValueByPath(newSettings, settingName, value);
         });
         
         // Update stored settings
@@ -510,6 +518,30 @@ class BaseInspector {
      */
     isObject(item) {
         return (item && typeof item === 'object' && !Array.isArray(item));
+    }
+
+    sendSettings() {
+        this.saveActionSettings();
+        this.saveGlobalSettings();
+    }
+
+    getValueByPath(obj, path) {
+        return path.split('.').reduce((current, key) => current?.[key], obj);
+    }
+
+    setValueByPath(obj, path, value) {
+        const keys = path.split('.');
+        let target = obj;
+
+        for (let i = 0; i < keys.length - 1; i++) {
+            const key = keys[i];
+            if (!this.isObject(target[key])) {
+                target[key] = {};
+            }
+            target = target[key];
+        }
+
+        target[keys[keys.length - 1]] = value;
     }
 }
 

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/cache-manager.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/cache-manager.js
@@ -17,6 +17,7 @@ class CacheManager {
             addedToLibrary: null,
             rating: null,
             currentPlaybackTime: null,
+            currentPlaybackDuration: null,
             songDisplaySettings: null
         };
     }

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
@@ -131,6 +131,17 @@ async function updateNowPlayingActionTile(artwork, title, artist) {
     }
 }
 
+async function refreshNowPlayingTile() {
+    const cacheManager = window.cacheManager;
+    if (!cacheManager) return;
+
+    const artwork = cacheManager.get('artwork');
+    const songName = cacheManager.get('song');
+    const artistName = cacheManager.get('artist');
+
+    await updateNowPlayingActionTile(artwork, songName, artistName);
+}
+
 // Playback state tracking
 let currentRepeatMode = 0; // 0: off, 1: repeat one, 2: repeat all, 3: disabled
 let currentShuffleMode = 0; // 0: off, 1: on, 2: disabled
@@ -541,6 +552,7 @@ window.CiderDeckPlayback = {
     goBack,
     updatePlaybackModes,
     setPlaybackTime,
+    refreshNowPlayingTile,
     formatSongInfo,
     getCurrentRepeatMode: () => currentRepeatMode,
     getCurrentShuffleMode: () => currentShuffleMode,

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
@@ -480,7 +480,6 @@ async function setPlaybackStatus(status) {
         window.contexts.toggleAction?.forEach(context => {
             $SD.setState(context, normalizedStatus ? 1 : 0);
         });
-        refreshNowPlayingTile();
         logger.debug(`Updated playback status: ${normalizedState}`);
     }
 }

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
@@ -294,11 +294,16 @@ async function setDefaults() {
                 };
                 $SD.setFeedback(context, feedbackPayload);
                 logger.info("Set default feedback for Cider Playback Action");
+            } else if (actionKey === 'albumArtGridAction') {
+                $SD.setState(context, 0);
+                $SD.setImage(context, "actions/assets/buttons/icon", 0);
             } else {
                 $SD.setState(context, 0);
             }
         });
     });
+
+    window.CiderDeckAlbumArtGrid?.setDefaultStates();
 }
 
 /**
@@ -366,7 +371,8 @@ async function setData(data) {
         return;
     }
 
-    let artwork = cacheManager.get('artwork');
+    const previousArtwork = cacheManager.get('artwork');
+    let artwork = previousArtwork;
 
     if (attributes?.artwork) {
         artwork = attributes.artwork?.url?.replace('{w}', attributes?.artwork?.width).replace('{h}', attributes?.artwork?.height);
@@ -384,7 +390,11 @@ async function setData(data) {
     
     let logMessage = "[DEBUG] [Playback] ";
     
-    if (cacheManager.checkAndUpdate('artwork', artwork) && artwork) {
+    if (cacheManager.checkAndUpdate('artwork', artwork)) {
+        window.CiderDeckAlbumArtGrid?.notifyArtworkChanged(previousArtwork, artwork);
+    }
+
+    if (previousArtwork !== artwork && artwork) {
         shouldUpdateNowPlayingTile = true;
         artworkLogger.debug(`Updating artwork from: ${artwork}`);
         const utils = window.CiderDeckUtils;

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/playback.js
@@ -23,6 +23,8 @@ const shuffleLogger = logger.category('Shuffle');
 const artworkLogger = window.CiderDeckLogger?.createLogger('Artwork') || logger;
 const nowPlayingTileLogger = logger.category('NowPlayingTile');
 let nowPlayingRenderRequestId = 0;
+const DIAL_SEEK_SECONDS = 5;
+const DIAL_PROGRESS_COLOR = '#e41b56';
 
 // Debounce function for logging
 const debounce = (func, wait) => {
@@ -91,6 +93,54 @@ function normalizePlaybackState(playbackState) {
         return playbackState ? 'playing' : 'paused';
     }
     return 'paused';
+}
+
+function formatClock(totalSeconds) {
+    if (!Number.isFinite(totalSeconds) || totalSeconds < 0) {
+        return '--:--';
+    }
+
+    const rounded = Math.max(0, Math.floor(totalSeconds));
+    const hours = Math.floor(rounded / 3600);
+    const minutes = Math.floor((rounded % 3600) / 60);
+    const seconds = rounded % 60;
+
+    if (hours > 0) {
+        return `${hours}:${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+    }
+
+    return `${minutes}:${String(seconds).padStart(2, '0')}`;
+}
+
+function getDialTimeDisplay(currentTime, duration) {
+    const mode = window.ciderDeckSettings?.dial?.timeDisplayMode || 'remaining';
+    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+    const safeCurrentTime = Number.isFinite(currentTime) ? Math.max(0, Math.min(currentTime, safeDuration || currentTime)) : 0;
+
+    if (mode === 'elapsed') {
+        return formatClock(safeCurrentTime);
+    }
+
+    if (!safeDuration) {
+        return '--:--';
+    }
+
+    const remaining = Math.max(safeDuration - safeCurrentTime, 0);
+    return `-${formatClock(remaining)}`;
+}
+
+function getDialArtworkPlaceholder() {
+    if (window.ciderDeckSettings?.dial?.showIcons === false) {
+        return "actions/assets/buttons/blank";
+    }
+    return "actions/assets/buttons/media-playlist";
+}
+
+function getDialVolumePlaceholder() {
+    if (window.ciderDeckSettings?.dial?.showIcons === false) {
+        return "actions/assets/buttons/blank";
+    }
+    return "actions/assets/buttons/volume-off";
 }
 
 function renderNowPlayingTile(artworkDataUrl, title, artist, playbackState) {
@@ -236,8 +286,10 @@ async function setDefaults() {
         window.contexts[actionKey]?.forEach(context => {
             if (actionKey === 'ciderPlaybackAction') {
                 const feedbackPayload = {
-                    "icon1": "actions/assets/buttons/media-playlist",
-                    "icon2": "actions/assets/buttons/volume-off",
+                    "icon1": getDialArtworkPlaceholder(),
+                    "icon2": getDialVolumePlaceholder(),
+                    "progressText": "--:--",
+                    "volumeText": "0%",
                     "title": "Cider - N/A",
                 };
                 $SD.setFeedback(context, feedbackPayload);
@@ -323,6 +375,7 @@ async function setData(data) {
     const songName = attributes.name;
     const artistName = attributes.artistName;
     const albumName = attributes.albumName;
+    const durationMs = firstDefined(attributes?.durationInMillis, data.durationInMillis);
     let shouldUpdateNowPlayingTile = false;
     const paused = isPlaybackPaused(state);
 
@@ -341,9 +394,13 @@ async function setData(data) {
                 if (window.contexts.ciderPlaybackAction && window.contexts.ciderPlaybackAction[0]) {
                     // Check if user wants to show artwork on dial or use default Cider logo
                     const showArtworkOnDial = window.ciderDeckSettings?.dial?.showArtworkOnDial ?? true;
+                    const showIcons = window.ciderDeckSettings?.dial?.showIcons ?? true;
                     const dialLogger = logger.category('Dial');
-                    dialLogger.debug(`Show artwork on dial: ${showArtworkOnDial}`);
-                    if (showArtworkOnDial) {
+                    dialLogger.debug(`Show artwork on dial: ${showArtworkOnDial}, show icons: ${showIcons}`);
+                    if (!showIcons) {
+                        $SD.setFeedback(window.contexts.ciderPlaybackAction[0], { "icon1": "actions/assets/buttons/blank" });
+                        dialLogger.debug(`Set blank icon on dial`);
+                    } else if (showArtworkOnDial) {
                         $SD.setFeedback(window.contexts.ciderPlaybackAction[0], { "icon1": art64 });
                         dialLogger.debug(`Set artwork on dial`);
                     } else {
@@ -372,7 +429,7 @@ async function setData(data) {
         };
         
         // Format the text using the custom format from dial settings (or fallback to default)
-        const customFormat = dialSettings.customFormat || '{song} - {album}';
+        const customFormat = dialSettings.customFormat || '{artist} - {song}';
         const textPrefix = dialSettings.textPrefix || '';
         const fullTitle = textPrefix + formatSongInfo(customFormat, songInfo);
         
@@ -443,6 +500,12 @@ async function setData(data) {
     
     if (cacheManager.checkAndUpdate('artist', artistName)) {
         shouldUpdateNowPlayingTile = true;
+    }
+
+    if (Number.isFinite(durationMs)) {
+        const durationSeconds = durationMs > 1000 ? durationMs / 1000 : durationMs;
+        cacheManager.set('currentPlaybackDuration', durationSeconds);
+        window.currentPlaybackDuration = durationSeconds;
     }
 
     if (lastNowPlayingPausedState !== paused) {
@@ -603,7 +666,7 @@ function formatSongInfo(template, songInfo) {
     // If no custom format is provided, use a default format
     if (!template || template === '') {
         formatLogger.debug("No template provided, using default format");
-        return `${songInfo.title || ''} - ${songInfo.album || ''}`;
+        return `${songInfo.artist || ''} - ${songInfo.title || ''}`;
     }
     
     formatLogger.debug(`Formatting with template: "${template}"`);
@@ -628,10 +691,14 @@ async function setPlaybackTime(time, duration) {
     const cacheManager = window.cacheManager;
     if (cacheManager) {
         cacheManager.set('currentPlaybackTime', time);
+        cacheManager.set('currentPlaybackDuration', duration);
     }
     window.currentPlaybackTime = time; // Backup in case cacheManager isn't available
+    window.currentPlaybackDuration = duration;
     
-    const progress = Math.round((time / duration) * 100);
+    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+    const progress = safeDuration > 0 ? Math.round((time / safeDuration) * 100) : 0;
+    const progressText = getDialTimeDisplay(time, safeDuration);
     
     // Create a specialized logger for playback time
     const timeLogger = logger.category('Time');
@@ -640,9 +707,40 @@ async function setPlaybackTime(time, duration) {
     // Update Stream Deck+ display if available
     if (window.contexts.ciderPlaybackAction && window.contexts.ciderPlaybackAction[0]) {
         const feedbackPayload = {
-            "indicator1": progress
+            "indicator1": progress,
+            "indicator1Color": DIAL_PROGRESS_COLOR,
+            "progressText": progressText
         };
         $SD.setFeedback(window.contexts.ciderPlaybackAction[0], feedbackPayload);
+    }
+}
+
+async function rotatePlaybackPosition(payload) {
+    const ticks = Number(payload?.ticks || 0);
+    if (!ticks) return;
+
+    const currentTime = window.cacheManager?.get('currentPlaybackTime') ?? window.currentPlaybackTime ?? 0;
+    const duration = window.cacheManager?.get('currentPlaybackDuration') ?? window.currentPlaybackDuration ?? 0;
+    const safeDuration = Number.isFinite(duration) && duration > 0 ? duration : 0;
+    if (!safeDuration) return;
+
+    const nextPosition = Math.max(0, Math.min(safeDuration, currentTime + (ticks * DIAL_SEEK_SECONDS)));
+    await window.CiderDeckUtils.comRPC("POST", "seek", true, { position: nextPosition });
+    setPlaybackTime(nextPosition, safeDuration);
+}
+
+async function rotateTrackSkip(payload) {
+    const ticks = Number(payload?.ticks || 0);
+    if (!ticks) return;
+
+    const utils = window.CiderDeckUtils;
+    if (!utils?.comRPC) {
+        return;
+    }
+
+    const endpoint = ticks > 0 ? "next" : "previous";
+    for (let i = 0; i < Math.abs(ticks); i++) {
+        await utils.comRPC("POST", endpoint);
     }
 }
 
@@ -658,6 +756,8 @@ window.CiderDeckPlayback = {
     goBack,
     updatePlaybackModes,
     setPlaybackTime,
+    rotatePlaybackPosition,
+    rotateTrackSkip,
     refreshNowPlayingTile,
     formatSongInfo,
     getCurrentRepeatMode: () => currentRepeatMode,

--- a/src/sh.cider.streamdeck.sdPlugin/libs/js/volume.js
+++ b/src/sh.cider.streamdeck.sdPlugin/libs/js/volume.js
@@ -50,9 +50,14 @@ async function handleVolumeChange(action, context, direction, payload) {
             isMuted = false;
             newVolume = previousVolume;
         } else if (direction === 'mute') {
-            isMuted = !isMuted;
-            previousVolume = currentVolume;
-            newVolume = isMuted ? 0 : previousVolume;
+            if (!isMuted) {
+                previousVolume = currentVolume;
+                isMuted = true;
+                newVolume = 0;
+            } else {
+                isMuted = false;
+                newVolume = previousVolume ?? currentVolume;
+            }
         } else if (direction === 'up' || direction === 'down') {
             newVolume = direction === 'up' 
                 ? Math.min(currentVolume + volumeStep / 100, 1) 
@@ -96,7 +101,10 @@ function updateVolumeDisplay(context, volume) {
     
     // Determine the appropriate icon based on volume level
     let iconName;
-    if (volumePercentage === 0) {
+    const showIcons = window.ciderDeckSettings?.dial?.showIcons ?? true;
+    if (!showIcons) {
+        iconName = "blank";
+    } else if (volumePercentage === 0) {
         iconName = "volume-off";
     } else if (volumePercentage <= 50) {
         iconName = "volume-down-1";
@@ -108,7 +116,8 @@ function updateVolumeDisplay(context, volume) {
     
     const feedbackPayload = {
         "indicator2": volumePercentage,
-        "icon2": `actions/assets/buttons/${iconName}`
+        "icon2": `actions/assets/buttons/${iconName}`,
+        "volumeText": `${volumePercentage}%`
     };
     $SD.setFeedback(context, feedbackPayload);
 }

--- a/src/sh.cider.streamdeck.sdPlugin/manifest.json
+++ b/src/sh.cider.streamdeck.sdPlugin/manifest.json
@@ -51,49 +51,6 @@
 			"PropertyInspectorPath": "actions/inspectors/dial-inspector.html"
 		},
 		{
-			"Icon": "actions/assets/app/desk-name-plate",
-			"Name": "Song Display",
-			"Controllers": ["Keypad"],
-			"DisableAutomaticStates": true,
-			"Encoder": {
-				"layout": "$B1",
-				"TriggerDescription": {
-					"Touch": "Nothing happens when you press this button."
-				}
-			},
-			"States": [
-				{
-					"Image": "actions/assets/buttons/blank"
-				}
-			],
-			"Tooltip": "Provides a tile to show the currently playing song from Cider.",
-			"UUID": "sh.cider.streamdeck.songname",
-			"PropertyInspectorPath": "actions/inspectors/song-display-inspector.html"
-		},
-		{
-			"Icon": "actions/assets/app/image-sparkle",
-			"Name": "Album Art",
-			"Controllers": ["Keypad"],
-			"DisableAutomaticStates": true,
-			"Encoder": {
-				"layout": "$B1",
-				"TriggerDescription": {
-					"Touch": "Nothing happens when you press this button."
-				}
-			},
-			"States": [
-				{
-					"Image": "actions/assets/buttons/icon"
-				},
-				{
-					"Image": "actions/assets/buttons/offline/icon"
-				}
-			],
-			"Tooltip": "Provides a tile to show the currently playing song's Album Art from Cider.",
-			"UUID": "sh.cider.streamdeck.albumart",
-			"PropertyInspectorPath": "actions/inspectors/inspector.html"
-		},
-		{
 			"Icon": "actions/assets/app/media-play-pause-toggle",
 			"Name": "Toggle Playback",
 			"Controllers": ["Keypad"],
@@ -247,6 +204,29 @@
 			"PropertyInspectorPath": "actions/inspectors/inspector.html"
 		},
 		{
+			"Icon": "actions/assets/app/media-playlist",
+			"Name": "Play Playlist",
+			"Controllers": ["Keypad"],
+			"DisableAutomaticStates": true,
+			"Encoder": {
+				"layout": "$B1",
+				"TriggerDescription": {
+					"Touch": "Pressing this button will start your configured playlist in Cider."
+				}
+			},
+			"States": [
+				{
+					"Image": "actions/assets/buttons/media-playlist"
+				},
+				{
+					"Image": "actions/assets/buttons/offline/media-playlist"
+				}
+			],
+			"Tooltip": "Starts a configured Apple Music playlist in Cider.",
+			"UUID": "sh.cider.streamdeck.playlist",
+			"PropertyInspectorPath": "actions/inspectors/playlist-inspector.html"
+		},
+		{
 			"Icon": "actions/assets/app/thumbs-down",
 			"Name": "Dislike",
 			"Controllers": ["Keypad"],
@@ -345,13 +325,13 @@
 		},
 		{
 			"Icon": "actions/assets/app/icon",
-			"Name": "Cider Logo",
+			"Name": "Launch / Now Playing",
 			"Controllers": ["Keypad"],
 			"DisableAutomaticStates": true,
 			"Encoder": {
 				"layout": "$B1",
 				"TriggerDescription": {
-					"Touch": "Nothing happens when you press this button."
+					"Touch": "Launches Cider when it is closed, or toggles Play/Pause when Cider is running."
 				}
 			},
 			"States": [
@@ -362,7 +342,7 @@
 					"Image": "actions/assets/buttons/offline/icon"
 				}
 			],
-			"Tooltip": "Simple tile to show the Cider logo, useful for decorative purposes.",
+			"Tooltip": "Shows Cider when offline and now-playing artwork with song info when online.",
 			"UUID": "sh.cider.streamdeck.ciderlogo",
 			"PropertyInspectorPath": "actions/inspectors/inspector.html"
 		}

--- a/src/sh.cider.streamdeck.sdPlugin/manifest.json
+++ b/src/sh.cider.streamdeck.sdPlugin/manifest.json
@@ -325,13 +325,13 @@
 		},
 		{
 			"Icon": "actions/assets/app/icon",
-			"Name": "Launch / Now Playing",
+			"Name": "Now Playing",
 			"Controllers": ["Keypad"],
 			"DisableAutomaticStates": true,
 			"Encoder": {
 				"layout": "$B1",
 				"TriggerDescription": {
-					"Touch": "Launches Cider when it is closed, or toggles Play/Pause when Cider is running."
+					"Touch": "Pressing this button will toggle playback (Play/Pause) in Cider."
 				}
 			},
 			"States": [
@@ -342,9 +342,10 @@
 					"Image": "actions/assets/buttons/offline/icon"
 				}
 			],
-			"Tooltip": "Shows Cider when offline and now-playing artwork with song info when online.",
+			"Tooltip": "Shows now-playing artwork with song info and toggles playback in Cider.",
 			"UUID": "sh.cider.streamdeck.ciderlogo",
 			"PropertyInspectorPath": "actions/inspectors/inspector.html"
 		}
 	]
 }
+

--- a/src/sh.cider.streamdeck.sdPlugin/manifest.json
+++ b/src/sh.cider.streamdeck.sdPlugin/manifest.json
@@ -30,7 +30,7 @@
 			"DisableAutomaticStates": true,
 			"Encoder": {
 				"Icon": "actions/assets/app/icon",
-				"layout": "$C1",
+				"layout": "layouts/cider-playback.json",
 				"TriggerDescription": {
 					"Push": "Mute/unmute the volume in Cider.",
 					"Left": "Lower the volume by 1% in Cider.",

--- a/src/sh.cider.streamdeck.sdPlugin/manifest.json
+++ b/src/sh.cider.streamdeck.sdPlugin/manifest.json
@@ -227,6 +227,29 @@
 			"PropertyInspectorPath": "actions/inspectors/playlist-inspector.html"
 		},
 		{
+			"Icon": "actions/assets/app/icon",
+			"Name": "Album Art Tile",
+			"Controllers": ["Keypad"],
+			"DisableAutomaticStates": true,
+			"Encoder": {
+				"layout": "$B1",
+				"TriggerDescription": {
+					"Touch": "Displays one slice of the current album artwork."
+				}
+			},
+			"States": [
+				{
+					"Image": "actions/assets/buttons/icon"
+				},
+				{
+					"Image": "actions/assets/buttons/offline/icon"
+				}
+			],
+			"Tooltip": "Displays one tile of the current album artwork so you can build larger album-art grids.",
+			"UUID": "sh.cider.streamdeck.albumartgrid",
+			"PropertyInspectorPath": "actions/inspectors/album-art-grid-inspector.html"
+		},
+		{
 			"Icon": "actions/assets/app/thumbs-down",
 			"Name": "Dislike",
 			"Controllers": ["Keypad"],


### PR DESCRIPTION
**Why**
The plugin needed a more complete playback surface on Stream Deck, especially for Now Playing visibility and Stream Deck+ dial usability. This work adds playlist support, improves Now Playing reliability, and upgrades the dial from the stock layout to a custom playback-focused experience.

**What**
- Added a playlist action with inspector support.
- Added and improved the Now Playing tile/action.
- Fixed stale Now Playing state on page changes and action re-appear.
- Reduced redraw flicker and stabilized paused/playback rendering.
- Improved previous-track timing behavior.
- Replaced the built-in Stream Deck+ dial layout with a custom playback layout.
- Added track-time and volume text indicators on the dial.
- Added a dial display option for time remaining vs time played.
- Changed the default dial text format to {artist} - {song}.
- Added touch feedback animation for dial-screen taps.
- Fixed the dedicated favorite action so it toggles correctly.
- Fixed dial mute/unmute so it restores the prior volume.
- Added GitHub release workflow support and updated docs.

**Testing**
Checked modified JS files with node --check
Validated the custom layout JSON
Manually tested the updated dial and Now Playing behavior in Stream Deck