### PR TITLE
Only run marquee rendering when text overflows

### DIFF
--- a/src/actions/playback-dial.ts
+++ b/src/actions/playback-dial.ts
@@ -159,7 +159,7 @@ export class PlaybackDialAction extends CiderDialAction {
 			this.lastTrackId = trackId;
 			this.offset = 0;
 		}
-		this.setAnimating(state.online && !!state.nowPlaying);
+		this.setAnimating(this.titleNeedsMarquee(state));
 
 		const feedback: Record<string, string | number> = this.buildFeedback(dial, state);
 		await this.attachIcon(dial, state, feedback);
@@ -244,6 +244,10 @@ export class PlaybackDialAction extends CiderDialAction {
 	private titleText(state: Readonly<PlayerState>): string {
 		const title = state.nowPlaying?.title || "Not Playing";
 		return this.animating ? marqueeWindow(title, TITLE_WIDTH, this.offset) : title;
+	}
+
+	private titleNeedsMarquee(state: Readonly<PlayerState>): boolean {
+		return state.online && (state.nowPlaying?.title?.length ?? 0) > TITLE_WIDTH;
 	}
 
 	private setAnimating(on: boolean): void {

--- a/src/actions/song-display.ts
+++ b/src/actions/song-display.ts
@@ -1,8 +1,14 @@
-import { action, type KeyAction } from "@elgato/streamdeck";
+import {
+	action,
+	type DidReceiveSettingsEvent,
+	type KeyAction,
+	type WillAppearEvent,
+	type WillDisappearEvent,
+} from "@elgato/streamdeck";
 import { UUID } from "../manifest-uuids";
 import type { PlayerState } from "../models/player-state";
 import type { SongDisplaySettings } from "../models/settings";
-import { renderOfflineSvg, renderSongSvg } from "../rendering/svg-song";
+import { renderOfflineSvg, renderSongSvg, songNeedsMarquee } from "../rendering/svg-song";
 import { CiderKeyAction } from "./base/cider-action";
 
 const TICK_ID = "song-display";
@@ -13,6 +19,8 @@ export class SongDisplayAction extends CiderKeyAction {
 	private offset = 0;
 	private animating = false;
 	private lastTrackId: string | undefined;
+	private readonly settings = new Map<string, SongDisplaySettings>();
+	private readonly needsMarquee = new Map<string, boolean>();
 	private readonly lastSvg = new Map<string, string>();
 
 	protected slices(): ["track"] {
@@ -26,15 +34,35 @@ export class SongDisplayAction extends CiderKeyAction {
 			this.offset = 0;
 			this.lastSvg.clear();
 		}
-		this.setAnimating(state.online && !!state.nowPlaying);
 		this.renderAll(state);
+		this.updateTicker();
 	}
 
-	protected async paint(action: KeyAction, state: Readonly<PlayerState>): Promise<void> {
-		const settings = (await action.getSettings()) as SongDisplaySettings;
+	override onWillAppear(ev: WillAppearEvent): void {
+		this.settings.set(ev.action.id, (ev.payload.settings ?? {}) as SongDisplaySettings);
+		super.onWillAppear(ev);
+	}
+
+	override onWillDisappear(ev: WillDisappearEvent): void {
+		this.settings.delete(ev.action.id);
+		this.needsMarquee.delete(ev.action.id);
+		this.lastSvg.delete(ev.action.id);
+		super.onWillDisappear(ev);
+		this.updateTicker();
+	}
+
+	protected override paintInstance(ev: WillAppearEvent, state: Readonly<PlayerState>): void {
+		if (ev.action.isKey()) this.paint(ev.action, state);
+		this.updateTicker();
+	}
+
+	protected paint(action: KeyAction, state: Readonly<PlayerState>): void {
+		const settings = this.settings.get(action.id) ?? {};
+		const needsMarquee = state.online && !!state.nowPlaying && songNeedsMarquee(state.nowPlaying, settings);
+		this.needsMarquee.set(action.id, needsMarquee);
 		const svg = !state.online
 			? renderOfflineSvg(settings.backgroundColor)
-			: renderSongSvg(state.nowPlaying, settings, this.animating ? this.offset : undefined);
+			: renderSongSvg(state.nowPlaying, settings, needsMarquee ? this.offset : undefined);
 		if (this.lastSvg.get(action.id) === svg) return; // skip redundant frames
 		this.lastSvg.set(action.id, svg);
 		void action.setImage(svg);
@@ -59,8 +87,20 @@ export class SongDisplayAction extends CiderKeyAction {
 		}
 	}
 
+	private updateTicker(): void {
+		for (const needed of this.needsMarquee.values()) {
+			if (needed) {
+				this.setAnimating(true);
+				return;
+			}
+		}
+		this.setAnimating(false);
+	}
+
 	protected override onLastDisappear(): void {
 		this.setAnimating(false);
+		this.settings.clear();
+		this.needsMarquee.clear();
 		this.lastSvg.clear();
 	}
 
@@ -68,8 +108,10 @@ export class SongDisplayAction extends CiderKeyAction {
 		this.lastSvg.clear();
 	}
 
-	override async onDidReceiveSettings(): Promise<void> {
-		this.lastSvg.clear(); // formatting changed; force re-render
-		this.renderAll(this.store.snapshot);
+	override onDidReceiveSettings(ev: DidReceiveSettingsEvent): void {
+		this.settings.set(ev.action.id, (ev.payload.settings ?? {}) as SongDisplaySettings);
+		this.lastSvg.delete(ev.action.id); // formatting changed; force re-render
+		if (ev.action.isKey()) this.paint(ev.action, this.store.snapshot);
+		this.updateTicker();
 	}
 }


### PR DESCRIPTION
This trims some idle rendering work from the Song Display key and Playback Dial.
Previously, both views started the shared marquee ticker whenever a track was present, even if the title/text already fit and there was nothing to scroll. The Song Display action also re-read settings during paints. This changes the marquee path to be demand-driven:
Cache Song Display settings from Stream Deck lifecycle/settings events.
Track whether each visible Song Display key actually needs marquee animation.
Start the shared ticker only when at least one visible Song Display key overflows.
Avoid animating Playback Dial titles unless the title exceeds the dial title width.
This should reduce unnecessary setImage/setFeedback churn for common short titles while preserving the existing scrolling behavior for long text.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ciderapp/codesmith/CiderDeck/pr/26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785291233&installation_id=125908741&pr_number=26&repository=ciderapp%2FCiderDeck&return_to=https%3A%2F%2Fgithub.com%2Fciderapp%2FCiderDeck%2Fpull%2F26&signature=8c8f6324a37f75e1e0c9c4cb4475f3da29e35abf52bc0c16980ee1527ef92188"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->