### PR TITLE
Add playback toggle support to Album Art Grid action

### DIFF
--- a/sh.cider.streamdeck.sdPlugin/ui/album-art-grid.html
+++ b/sh.cider.streamdeck.sdPlugin/ui/album-art-grid.html
@@ -21,7 +21,7 @@
 			Place several of these in a contiguous block - a <b>2×2</b> is the classic - and they
 			tile the current album art across the keys to form one large cover. They arrange
 			themselves from their positions, so any rectangle works (2×2, 3×2, a tall 1×3…). A
-			single tile just shows the whole cover.
+			single tile just shows the whole cover. Pressing any tile will toggle playback on the current track.
 		</p>
 
 		<script src="lib/cider-connection.js"></script>

--- a/src/actions/album-art-grid.ts
+++ b/src/actions/album-art-grid.ts
@@ -1,6 +1,7 @@
 import {
 	action,
 	type KeyAction,
+	type KeyDownEvent,
 	type WillAppearEvent,
 	type WillDisappearEvent,
 } from "@elgato/streamdeck";
@@ -16,6 +17,8 @@ import { CiderKeyAction } from "./base/cider-action";
  * its slice of the current artwork so the block reads as one large cover. A
  * single instance just shows the whole cover (like Album Art). Adding/removing a
  * cell re-tiles every cell.
+ *
+ * Clicking any cell toggles play/pause.
  */
 @action({ UUID: UUID.ALBUM_ART_GRID })
 export class AlbumArtGridAction extends CiderKeyAction {
@@ -36,50 +39,117 @@ export class AlbumArtGridAction extends CiderKeyAction {
 		this.scheduleRepaint();
 	}
 
+	/**
+	 * Click album art = toggle play/pause
+	 */
+	override async onKeyDown(ev: KeyDownEvent): Promise<void> {
+		await this.run(ev.action, () => this.client.toggle());
+	}
+
 	protected async paint(action: KeyAction, state: Readonly<PlayerState>): Promise<void> {
 		const g = this.gridFor(action);
+
 		let svg: string;
+
 		if (!state.online) {
-			svg = renderArtworkCell(undefined, g.gx, g.gy, g.cols, g.rows, false);
+			svg = renderArtworkCell(
+				undefined,
+				g.gx,
+				g.gy,
+				g.cols,
+				g.rows,
+				false
+			);
 		} else {
 			const paused = !!state.nowPlaying && !state.playing;
+
 			// Request enough resolution that each cell still looks sharp (~2x per cell).
 			const px = Math.min(1024, Math.max(g.cols, g.rows) * 320);
-			const url = resolveArtwork(state.nowPlaying?.artworkUrl, px);
-			const art = url ? await this.services.artwork.getDataUri(url) : undefined;
-			svg = renderArtworkCell(art, g.gx, g.gy, g.cols, g.rows, paused);
+
+			const url = resolveArtwork(
+				state.nowPlaying?.artworkUrl,
+				px
+			);
+
+			const art = url
+				? await this.services.artwork.getDataUri(url)
+				: undefined;
+
+			svg = renderArtworkCell(
+				art,
+				g.gx,
+				g.gy,
+				g.cols,
+				g.rows,
+				paused
+			);
 		}
+
 		if (this.lastSvg.get(action.id) === svg) return;
+
 		this.lastSvg.set(action.id, svg);
 		void action.setImage(svg);
 	}
 
-	/** This cell's position + the grid's size, from the bounding box of all cells. */
-	private gridFor(action: KeyAction): { gx: number; gy: number; cols: number; rows: number } {
+	/**
+	 * This cell's position + the grid's size,
+	 * from the bounding box of all cells.
+	 */
+	private gridFor(action: KeyAction): {
+		gx: number;
+		gy: number;
+		cols: number;
+		rows: number;
+	} {
 		let minC = Number.POSITIVE_INFINITY;
 		let minR = Number.POSITIVE_INFINITY;
 		let maxC = Number.NEGATIVE_INFINITY;
 		let maxR = Number.NEGATIVE_INFINITY;
+
 		for (const a of this.actions) {
 			if (!a.isKey()) continue;
+
 			const c = a.coordinates;
 			if (!c) continue;
+
 			minC = Math.min(minC, c.column);
 			maxC = Math.max(maxC, c.column);
 			minR = Math.min(minR, c.row);
 			maxR = Math.max(maxR, c.row);
 		}
+
 		const c = action.coordinates;
-		if (!c || !Number.isFinite(minC)) return { gx: 0, gy: 0, cols: 1, rows: 1 };
-		return { gx: c.column - minC, gy: c.row - minR, cols: maxC - minC + 1, rows: maxR - minR + 1 };
+
+		if (!c || !Number.isFinite(minC)) {
+			return {
+				gx: 0,
+				gy: 0,
+				cols: 1,
+				rows: 1,
+			};
+		}
+
+		return {
+			gx: c.column - minC,
+			gy: c.row - minR,
+			cols: maxC - minC + 1,
+			rows: maxR - minR + 1,
+		};
 	}
 
 	private scheduleRepaint(): void {
-		if (this.repaintTimer) return; // coalesce a burst of appears/disappears
+		if (this.repaintTimer) return;
+
 		this.repaintTimer = setTimeout(() => {
 			this.repaintTimer = undefined;
+
 			const state = this.store.snapshot;
-			for (const a of this.actions) if (a.isKey()) void this.paint(a, state);
+
+			for (const a of this.actions) {
+				if (a.isKey()) {
+					void this.paint(a, state);
+				}
+			}
 		}, 60);
 	}
 
@@ -92,6 +162,7 @@ export class AlbumArtGridAction extends CiderKeyAction {
 			clearTimeout(this.repaintTimer);
 			this.repaintTimer = undefined;
 		}
+
 		this.lastSvg.clear();
 	}
 }


### PR DESCRIPTION
Pressing any tile in the Album Art Grid will now toggle playback of the current track.

I took inspiration from the Spotify Stream Deck plugin and thought this functionality would be a nice addition to CiderDeck.

I use the Stream Deck MK.2 (15 keys), and previously my main page had four separate buttons: album artwork, previous track, play/pause, and next track. I started running out of space on my main page, so I decided to combine the album artwork and playback control into the Album Art Grid.

This makes the grid more useful while keeping the interface cleaner and reducing the number of buttons needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ciderapp/codesmith/CiderDeck/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786305182&installation_id=125908741&pr_number=29&repository=ciderapp%2FCiderDeck&return_to=https%3A%2F%2Fgithub.com%2Fciderapp%2FCiderDeck%2Fpull%2F29&signature=b34f1501a015944381fb49810342ba97456a079e22fbb5d6389b1fbcd488e44e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->