### PR TITLE
fix(song-display): stop recursive settings repaint

### DIFF
--- a/sh.cider.streamdeck.sdPlugin/manifest.json
+++ b/sh.cider.streamdeck.sdPlugin/manifest.json
@@ -7,7 +7,7 @@
 	"UUID": "sh.cider.streamdeck",
 	"Icon": "actions/assets/app/icon",
 	"URL": "https://cider.sh",
-	"Version": "4.0.0.0",
+	"Version": "4.0.1.0",
 	"SDKVersion": 3,
 	"Nodejs": {
 		"Version": "20",

--- a/src/actions/song-display.ts
+++ b/src/actions/song-display.ts
@@ -1,4 +1,4 @@
-import { action, type KeyAction } from "@elgato/streamdeck";
+import { action, type DidReceiveSettingsEvent, type KeyAction, type WillAppearEvent } from "@elgato/streamdeck";
 import { UUID } from "../manifest-uuids";
 import type { PlayerState } from "../models/player-state";
 import type { SongDisplaySettings } from "../models/settings";
@@ -13,10 +13,16 @@ export class SongDisplayAction extends CiderKeyAction {
 	private offset = 0;
 	private animating = false;
 	private lastTrackId: string | undefined;
+	private readonly settings = new Map<string, SongDisplaySettings>();
 	private readonly lastSvg = new Map<string, string>();
 
 	protected slices(): ["track"] {
 		return ["track"];
+	}
+
+	override onWillAppear(ev: WillAppearEvent): void {
+		this.settings.set(ev.action.id, (ev.payload.settings ?? {}) as SongDisplaySettings);
+		super.onWillAppear(ev);
 	}
 
 	protected override repaintAll(state: Readonly<PlayerState>): void {
@@ -30,8 +36,8 @@ export class SongDisplayAction extends CiderKeyAction {
 		this.renderAll(state);
 	}
 
-	protected async paint(action: KeyAction, state: Readonly<PlayerState>): Promise<void> {
-		const settings = (await action.getSettings()) as SongDisplaySettings;
+	protected paint(action: KeyAction, state: Readonly<PlayerState>): void {
+		const settings = this.settings.get(action.id) ?? {};
 		const svg = !state.online
 			? renderOfflineSvg(settings.backgroundColor)
 			: renderSongSvg(state.nowPlaying, settings, this.animating ? this.offset : undefined);
@@ -61,6 +67,7 @@ export class SongDisplayAction extends CiderKeyAction {
 
 	protected override onLastDisappear(): void {
 		this.setAnimating(false);
+		this.settings.clear();
 		this.lastSvg.clear();
 	}
 
@@ -68,8 +75,9 @@ export class SongDisplayAction extends CiderKeyAction {
 		this.lastSvg.clear();
 	}
 
-	override async onDidReceiveSettings(): Promise<void> {
-		this.lastSvg.clear(); // formatting changed; force re-render
-		this.renderAll(this.store.snapshot);
+	override onDidReceiveSettings(ev: DidReceiveSettingsEvent): void {
+		this.settings.set(ev.action.id, (ev.payload.settings ?? {}) as SongDisplaySettings);
+		this.lastSvg.delete(ev.action.id); // formatting changed; force re-render
+		if (ev.action.isKey()) this.paint(ev.action, this.store.snapshot);
 	}
 }


### PR DESCRIPTION
`SongDisplayAction.paint()` requested action settings on every render. Stream Deck answers `getSettings()` with `didReceiveSettings`, and the action's handler repainted every tile, creating a self-sustaining settings-response loop that saturated both the plugin and Stream Deck host and caused extreme memory growth.

- Cache song-display settings from `willAppear` and `didReceiveSettings` lifecycle payloads instead of requesting them during paint.
- Repaint only the action whose settings changed and invalidate only its rendered SVG cache entry.
- Clear the per-action settings cache when the final song-display action disappears.
- Bump the plugin manifest from `4.0.0.0` to `4.0.1.0`; this is a separate commit so it can be omitted if Marketplace release versioning is managed elsewhere.

## Reproduction and validation

Before the fix, Stream Deck 7.5.1 on macOS reached an 8.1 GB physical footprint after approximately 5.5 minutes, ultimately peaking at 13.6 GB. Stream Deck and the CiderDeck Node process each continuously consumed approximately one CPU core.

After installing the patched plugin from this branch and restarting Stream Deck, a 6.5-minute `vmmap` observation remained stable: physical footprint moved from 437.4 MB to 421.5 MB with a 441.2 MB peak, and both processes settled to approximately 0% CPU.

I'm also fairly certain this fixes https://github.com/ciderapp/CiderDeck/issues/32 as well, since it would cause CPU usage of the underlying Stream Deck service to chew CPU like it was in a candy store.

- Local linked-plugin test on Stream Deck 7.5.1 (22901), macOS 27.0

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ciderapp/codesmith/CiderDeck/pr/37"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789102678&installation_model_id=19451&pr_number=37&repository=ciderapp%2FCiderDeck&return_to=https%3A%2F%2Fgithub.com%2Fciderapp%2FCiderDeck%2Fpull%2F37&signature=16916b4a6cbbdaf5a65ece9e672a91e3d09bf7008f284942e635b6bfd57a17e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->